### PR TITLE
fix account reward page

### DIFF
--- a/explorer/src/components/Account/AccountRewardList.tsx
+++ b/explorer/src/components/Account/AccountRewardList.tsx
@@ -8,7 +8,7 @@ import { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
 import { Spinner } from 'components/common/Spinner'
 import { PAGE_SIZE } from 'constants/general'
-import { INTERNAL_ROUTES } from 'constants/routes'
+import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { RewardEventOrderByInput, RewardsListQueryVariables } from 'gql/graphql'
@@ -73,6 +73,8 @@ export const AccountRewardList: FC = () => {
       skip: !inFocus,
       pollInterval: 6000,
     },
+    selectedChain?.isDomain ? Routes.nova : Routes.consensus,
+    'accountReward',
   )
 
   const {
@@ -208,9 +210,12 @@ export const AccountRewardList: FC = () => {
   useEffect(() => {
     setIsVisible(inView)
   }, [inView, setIsVisible])
+
   return (
     <div className='flex w-full flex-col align-middle'>
-      <AccountDetailsCard account={account} accountAddress={convertedAddress ?? '0x'} />
+      {convertedAddress && (
+        <AccountDetailsCard account={account} accountAddress={convertedAddress} />
+      )}
 
       <div className='mt-5 flex w-full justify-between'>
         <div className='text-base font-medium text-grayDark dark:text-white'>{`Rewards (${totalLabel})`}</div>


### PR DESCRIPTION
### **User description**
## fix account reward page


___

### **PR Type**
Bug fix


___

### **Description**
- Added a condition to check `selectedChain?.isDomain` to determine the appropriate route (`Routes.nova` or `Routes.consensus`).
- Updated the `useEffect` hook to set visibility based on the `inView` state.
- Wrapped the `AccountDetailsCard` component with a condition to check if `convertedAddress` is available before rendering.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AccountRewardList.tsx</strong><dd><code>Fix account reward page rendering and routing issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Account/AccountRewardList.tsx

<li>Added condition to check <code>selectedChain?.isDomain</code> to determine route.<br> <li> Updated <code>useEffect</code> to set visibility based on <code>inView</code>.<br> <li> Wrapped <code>AccountDetailsCard</code> component with a condition to check <br><code>convertedAddress</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/777/files#diff-76653fe8d97ca2af5519863f38224b10e4513c926811aafeb22cecba9f6461a3">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

