### PR TITLE
Fix full export for Acount extrinsics list and account rewards list

### DIFF
--- a/explorer/src/components/Account/AccountExtrinsicList.tsx
+++ b/explorer/src/components/Account/AccountExtrinsicList.tsx
@@ -59,6 +59,16 @@ export const AccountExtrinsicList: FC<Props> = ({ accountId }) => {
     [sorting],
   )
 
+  const where = useMemo(
+    () => ({
+      ...filters,
+      signer: {
+        id_eq: accountId,
+      },
+    }),
+    [accountId, filters],
+  )
+
   const variables = useMemo(() => {
     return {
       first: pagination.pageSize,
@@ -67,14 +77,9 @@ export const AccountExtrinsicList: FC<Props> = ({ accountId }) => {
           ? (pagination.pageIndex * pagination.pageSize).toString()
           : undefined,
       orderBy,
-      where: {
-        ...filters,
-        signer: {
-          id_eq: accountId,
-        },
-      },
+      where,
     }
-  }, [accountId, filters, orderBy, pagination.pageIndex, pagination.pageSize])
+  }, [orderBy, pagination.pageIndex, pagination.pageSize, where])
 
   const { setIsVisible } = useSquidQuery<
     ExtrinsicsByAccountIdQuery,
@@ -107,8 +112,11 @@ export const AccountExtrinsicList: FC<Props> = ({ accountId }) => {
 
   const fullDataDownloader = useCallback(
     () =>
-      downloadFullData(apolloClient, QUERY_ACCOUNT_EXTRINSICS, 'extrinsicsConnection', { orderBy }),
-    [apolloClient, orderBy],
+      downloadFullData(apolloClient, QUERY_ACCOUNT_EXTRINSICS, 'extrinsicsConnection', {
+        orderBy,
+        where,
+      }),
+    [apolloClient, orderBy, where],
   )
 
   const extrinsicsConnection = useMemo(() => data && data.extrinsicsConnection, [data])

--- a/explorer/src/components/Account/AccountRewardList.tsx
+++ b/explorer/src/components/Account/AccountRewardList.tsx
@@ -193,8 +193,9 @@ export const AccountRewardList: FC = () => {
     () =>
       downloadFullData(apolloClient, QUERY_REWARDS_LIST, 'rewardEventsConnection', {
         sortBy,
+        accountId: accountId ?? '',
       }),
-    [apolloClient, sortBy],
+    [accountId, apolloClient, sortBy],
   )
 
   useEffect(() => {


### PR DESCRIPTION
### **User description**
## Fix full export for Acount extrinsics list and account rewards list

- Download full board of a account extrinsics list
- Same for an account rewards list


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the full export logic for the account extrinsics list by adding memoization for the `where` filter and updating the `fullDataDownloader` to use this filter.
- Fixed the full export logic for the account rewards list by including `accountId` in the parameters for full data download.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AccountExtrinsicList.tsx</strong><dd><code>Fix full export logic for account extrinsics list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Account/AccountExtrinsicList.tsx

<li>Added <code>where</code> memoization for filtering extrinsics by account ID.<br> <li> Updated <code>variables</code> memoization to include <code>where</code>.<br> <li> Modified <code>fullDataDownloader</code> to use the new <code>where</code> filter.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/781/files#diff-8e7c6430932c097f9c7db0f1306071611fea0f7c673a329bb34811c468e6c894">+17/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountRewardList.tsx</strong><dd><code>Fix full export logic for account rewards list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Account/AccountRewardList.tsx

<li>Added <code>accountId</code> to the parameters for full data download.<br> <li> Updated <code>fullDataDownloader</code> to include <code>accountId</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/781/files#diff-76653fe8d97ca2af5519863f38224b10e4513c926811aafeb22cecba9f6461a3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

