### PR TITLE
We always miss the last page if the total % pageSize > 0

### DIFF
--- a/explorer/src/utils/table.ts
+++ b/explorer/src/utils/table.ts
@@ -1,2 +1,2 @@
 export const countTablePages = (totalCount: number, pageSize: number) =>
-  Math.max(1, Math.floor(totalCount / pageSize))
+  Math.max(1, Math.floor(totalCount / pageSize)) + (totalCount % pageSize > 0 ? 1 : 0)


### PR DESCRIPTION
### **User description**
We always miss the last page if the total % pageSize > 0


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where the last page was missed if the total count modulo page size was greater than zero.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>table.ts</strong><dd><code>Fix page count calculation to include last page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/utils/table.ts

<li>Fixed the calculation of total pages to include the last page if there <br>is a remainder.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/783/files#diff-eedb74e80058882ca609a5c5e193921d3f9a52ad3bb705472abdd85864370dd3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

