### PR TITLE
fix rpc data following domains states changes

### DIFF
--- a/explorer/src/hooks/useConsensusData.ts
+++ b/explorer/src/hooks/useConsensusData.ts
@@ -2,7 +2,7 @@ import useWallet from 'hooks/useWallet'
 import { useCallback } from 'react'
 import { useConsensusStates } from 'states/consensus'
 import {
-  ConfirmedDomainBlock,
+  ConfirmedDomainExecutionReceipt,
   DomainRegistry,
   DomainStakingSummary,
   PendingStakingOperationCount,
@@ -17,7 +17,7 @@ export const useConsensusData = () => {
     setSystem,
     setDomainRegistry,
     setDomainStakingSummary,
-    setLatestConfirmedDomainBlock,
+    setLatestConfirmedDomainExecutionReceipt,
     setNominatorCount,
     setOperatorIdOwner,
     setOperators,
@@ -41,7 +41,7 @@ export const useConsensusData = () => {
         // domains
         domainRegistry,
         domainStakingSummary,
-        latestConfirmedDomainBlock,
+        latestConfirmedDomainExecutionReceipt,
         nominatorCount,
         operatorIdOwner,
         operators,
@@ -53,9 +53,10 @@ export const useConsensusData = () => {
         // system
         api.rpc.system.chain(),
         api.rpc.system.name(),
+        // domains
         api.query.domains.domainRegistry.entries(),
         api.query.domains.domainStakingSummary.entries(),
-        api.query.domains.latestConfirmedDomainBlock.entries(),
+        api.query.domains.latestConfirmedDomainExecutionReceipt.entries(),
         api.query.domains.nominatorCount.entries(),
         api.query.domains.operatorIdOwner.entries(),
         api.query.domains.operators.entries(),
@@ -106,10 +107,10 @@ export const useConsensusData = () => {
       setDomainStakingSummary(
         domainStakingSummary.map((domain) => domain[1].toJSON() as DomainStakingSummary),
       )
-      setLatestConfirmedDomainBlock(
-        latestConfirmedDomainBlock.map((domainBlock) => ({
+      setLatestConfirmedDomainExecutionReceipt(
+        latestConfirmedDomainExecutionReceipt.map((domainBlock) => ({
           id: parseInt((domainBlock[0].toHuman() as string[])[0]),
-          ...(domainBlock[1].toJSON() as Omit<ConfirmedDomainBlock, 'id'>),
+          ...(domainBlock[1].toJSON() as Omit<ConfirmedDomainExecutionReceipt, 'id'>),
         })),
       )
       setNominatorCount(

--- a/explorer/src/states/consensus.ts
+++ b/explorer/src/states/consensus.ts
@@ -1,6 +1,6 @@
 import type { Deposit, Withdrawal } from '@autonomys/auto-consensus'
 import {
-  ConfirmedDomainBlock,
+  ConfirmedDomainExecutionReceipt,
   Domain,
   DomainRegistry,
   DomainStakingSummary,
@@ -28,7 +28,7 @@ export interface ConsensusDefaultState {
   // domains
   domainRegistry: DomainRegistry[]
   domainStakingSummary: DomainStakingSummary[]
-  latestConfirmedDomainBlock: ConfirmedDomainBlock[]
+  latestConfirmedDomainExecutionReceipt: ConfirmedDomainExecutionReceipt[]
   // latestSubmittedER: LatestSubmittedER[]
   nominatorCount: NominatorCount[]
   operatorIdOwner: OperatorIdOwner[]
@@ -51,7 +51,9 @@ interface ConsensusState extends ConsensusDefaultState {
   setSystem: (params: { chain: string; name: string }) => void
   setDomainRegistry: (domainRegistry: DomainRegistry[]) => void
   setDomainStakingSummary: (domainStakingSummary: DomainStakingSummary[]) => void
-  setLatestConfirmedDomainBlock: (latestConfirmedDomainBlock: ConfirmedDomainBlock[]) => void
+  setLatestConfirmedDomainExecutionReceipt: (
+    latestConfirmedDomainExecutionReceipt: ConfirmedDomainExecutionReceipt[],
+  ) => void
   setNominatorCount: (nominatorCount: NominatorCount[]) => void
   setOperatorIdOwner: (operatorIdOwner: OperatorIdOwner[]) => void
   setOperators: (operators: Operators[]) => void
@@ -77,7 +79,7 @@ const initialState: ConsensusDefaultState = {
   // domains
   domainRegistry: [],
   domainStakingSummary: [],
-  latestConfirmedDomainBlock: [],
+  latestConfirmedDomainExecutionReceipt: [],
   // latestSubmittedER: [],
   nominatorCount: [],
   operatorIdOwner: [],
@@ -104,8 +106,8 @@ export const useConsensusStates = create<ConsensusState>()(
       setSystem: (params) => set(() => ({ chain: params.chain, name: params.name })),
       setDomainRegistry: (domainRegistry) => set(() => ({ domainRegistry })),
       setDomainStakingSummary: (domainStakingSummary) => set(() => ({ domainStakingSummary })),
-      setLatestConfirmedDomainBlock: (latestConfirmedDomainBlock) =>
-        set(() => ({ latestConfirmedDomainBlock })),
+      setLatestConfirmedDomainExecutionReceipt: (latestConfirmedDomainExecutionReceipt) =>
+        set(() => ({ latestConfirmedDomainExecutionReceipt })),
       setNominatorCount: (nominatorCount) => set(() => ({ nominatorCount })),
       setOperatorIdOwner: (operatorIdOwner) => set(() => ({ operatorIdOwner })),
       setOperators: (operators) => set(() => ({ operators })),

--- a/explorer/src/types/consensus.ts
+++ b/explorer/src/types/consensus.ts
@@ -56,13 +56,9 @@ export type DomainStakingSummary = {
   }
 }
 
-export type ConfirmedDomainBlock = {
+export type ConfirmedDomainExecutionReceipt = {
   id: number
-  blockNumber: number
-  blockHash: string
-  parentBlockReceiptHash: string
-  stateRoot: string
-  extrinsicsRoot: string
+  domainBlockNumber: number
 }
 
 export type NominatorCount = {


### PR DESCRIPTION
### **User description**
## fix rpc data following domains states changes

from what I see domains.latestConfirmedDomainBlock chain state has been replaced by domains.latestConfirmedDomainExecutionReceipt and so this broke Astral rpc data logic...


___

### **PR Type**
Bug fix


___

### **Description**
- Replaced `ConfirmedDomainBlock` with `ConfirmedDomainExecutionReceipt` across multiple files to reflect changes in domain state management.
- Updated hooks, state management, and type definitions to use the new `ConfirmedDomainExecutionReceipt`.
- Modified API query references to align with the new domain execution receipt structure.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useConsensusData.ts</strong><dd><code>Update consensus data hooks to use new domain execution receipt</code></dd></summary>
<hr>

explorer/src/hooks/useConsensusData.ts

<li>Replaced <code>ConfirmedDomainBlock</code> with <code>ConfirmedDomainExecutionReceipt</code><br> <li> Updated function calls and state setters to use <br><code>ConfirmedDomainExecutionReceipt</code><br> <li> Modified API query references to use <br><code>latestConfirmedDomainExecutionReceipt</code><br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/787/files#diff-734fc7f643a5c569f33bad078492efc35cb5f716856b646e59a933a1f322c886">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>consensus.ts</strong><dd><code>Update consensus state management for domain execution receipt</code></dd></summary>
<hr>

explorer/src/states/consensus.ts

<li>Replaced <code>ConfirmedDomainBlock</code> with <code>ConfirmedDomainExecutionReceipt</code> in <br>state definitions<br> <li> Updated state setter functions to use <code>ConfirmedDomainExecutionReceipt</code><br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/787/files#diff-65292cb11b941bb083c14ec6116aae44a5b6525f0a35166a59698cd1e21d77a1">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>consensus.ts</strong><dd><code>Modify consensus types to use domain execution receipt</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/types/consensus.ts

<li>Replaced <code>ConfirmedDomainBlock</code> type with <br><code>ConfirmedDomainExecutionReceipt</code><br> <li> Updated type definition to reflect new structure<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/787/files#diff-e50d0c017ad68aed1dfe87e953f345c1d30af5efaf9ed0f2246e6b5feafcb88b">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

