### PR TITLE
Change tx status to show fail extrinsic in red X

### DIFF
--- a/explorer/src/components/WalletSideKick/PendingTransactions.tsx
+++ b/explorer/src/components/WalletSideKick/PendingTransactions.tsx
@@ -161,7 +161,7 @@ export const PendingTransactions: FC<PendingTransactionsProps> = ({
                   </div>
                   <div className='m-2 p-2'>
                     <StatusIcon
-                      status={tx.status !== TransactionStatus.Pending}
+                      status={tx.status === TransactionStatus.Success}
                       isPending={tx.status === TransactionStatus.Pending}
                     />
                   </div>

--- a/explorer/src/components/WalletSideKick/PendingTransactions.tsx
+++ b/explorer/src/components/WalletSideKick/PendingTransactions.tsx
@@ -160,7 +160,10 @@ export const PendingTransactions: FC<PendingTransactionsProps> = ({
                     </span>
                   </div>
                   <div className='m-2 p-2'>
-                    <StatusIcon status={tx.status !== TransactionStatus.Pending} />
+                    <StatusIcon
+                      status={tx.status !== TransactionStatus.Pending}
+                      isPending={tx.status === TransactionStatus.Pending}
+                    />
                   </div>
                   <div className='m-2 p-2'>
                     <TrashIcon className='size-5' stroke='red' onClick={() => handleRemove(tx)} />

--- a/explorer/src/components/common/StatusIcon.tsx
+++ b/explorer/src/components/common/StatusIcon.tsx
@@ -1,14 +1,16 @@
-import { CheckCircleIcon, ClockIcon } from '@heroicons/react/24/outline'
+import { CheckCircleIcon, ClockIcon, XCircleIcon } from '@heroicons/react/24/outline'
 import { FC } from 'react'
 
 type Props = {
   status: boolean
+  isPending?: boolean
 }
 
-export const StatusIcon: FC<Props> = ({ status }) => {
+export const StatusIcon: FC<Props> = ({ status, isPending }) => {
+  if (isPending) return <ClockIcon className='size-5' stroke='orange' />
   return status ? (
     <CheckCircleIcon className='size-5' stroke='#37D058' />
   ) : (
-    <ClockIcon className='size-5' stroke='orange' />
+    <XCircleIcon className='size-5' stroke='#D70040' />
   )
 }


### PR DESCRIPTION
### **User description**
## Change tx status to show fail extrinsic in red X

Fail extrinsic were shown with an orange clock, leading to assume these were pending.

Now it's a red X

![image](https://github.com/user-attachments/assets/72072e31-e0db-41e4-9a88-965a2ad7d32f)


___

### **PR Type**
enhancement


___

### **Description**
- Updated the `StatusIcon` component to display a red `XCircleIcon` for failed transactions.
- Added an `isPending` prop to the `StatusIcon` component to differentiate between pending and failed statuses.
- Modified the `PendingTransactions` component to pass the `isPending` prop to the `StatusIcon` component.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PendingTransactions.tsx</strong><dd><code>Update transaction status icon handling in PendingTransactions</code></dd></summary>
<hr>

explorer/src/components/WalletSideKick/PendingTransactions.tsx

<li>Updated <code>StatusIcon</code> component to handle failed transactions.<br> <li> Added <code>isPending</code> prop to <code>StatusIcon</code> component.<br> <li> Modified the display logic for transaction status icons.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/788/files#diff-c3c75fc52086f33f639d19fc0e9b11dca1c98c0e056dfb4ad667e72876a696f3">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StatusIcon.tsx</strong><dd><code>Add red X icon for failed transaction status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/common/StatusIcon.tsx

<li>Imported <code>XCircleIcon</code> for failed transaction status.<br> <li> Added <code>isPending</code> prop to differentiate between pending and failed <br>statuses.<br> <li> Changed icon for failed transactions to a red <code>XCircleIcon</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/788/files#diff-99c34bdcd2d1657e57c13986ec24d70aabd3fc69d708ec70a9f92b8f3387f645">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

