### PR TITLE
fixes to hasura service docker compose

### DIFF
--- a/indexers/squid-blockexplorer/docker-compose.yml
+++ b/indexers/squid-blockexplorer/docker-compose.yml
@@ -14,11 +14,11 @@ services:
   graphql-engine:
     image: hasura/graphql-engine:v2.40.0
     depends_on:
-      - "postgres"
+      - "db"
     restart: always
     environment:
       ## postgres database to store Hasura metadata
-      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://\${POSTGRES_USER}:\${POSTGRES_PASSWORD}@db:5432/\${POSTGRES_DB}
+      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       ## enable the console served by server
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set "false" to disable console
       ## enable debugging mode. It is recommended to disable this in production
@@ -26,7 +26,7 @@ services:
       ## uncomment next line to run console offline (i.e load console assets from server instead of CDN)
       # HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
       ## uncomment next line to set an admin secret
-      HASURA_GRAPHQL_ADMIN_SECRET: \${HASURA_GRAPHQL_ADMIN_SECRET}
+      HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET}
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: user
       HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES: "true"
     ports:


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the `graphql-engine` service in `docker-compose.yml` to depend on `db` instead of `postgres`.
- Corrected the format of the `HASURA_GRAPHQL_METADATA_DATABASE_URL` environment variable.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Fix Hasura service configuration in Docker Compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/squid-blockexplorer/docker-compose.yml

<li>Changed dependency name from <code>postgres</code> to <code>db</code> for the <code>graphql-engine</code> <br>service.<br> <li> Corrected the <code>HASURA_GRAPHQL_METADATA_DATABASE_URL</code> environment <br>variable format.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/810/files#diff-a7a245565e49a17c46644f109c0c37813eabb658b9a2aaadde32029a43688f60">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

