### PR TITLE
Raw status is mention twice in operators table editor

### DIFF
--- a/explorer/src/constants/tables.ts
+++ b/explorer/src/constants/tables.ts
@@ -97,7 +97,6 @@ export const AVAILABLE_COLUMNS: AvailableColumns = {
     { name: 'current_epoch_rewards', label: 'Current Epoch Rewards', isSelected: false },
     { name: 'current_total_shares', label: 'Total Shares', isSelected: false },
     { name: 'current_share_price', label: 'Current Share Price', isSelected: false },
-    { name: 'raw_status', label: 'Raw Status', isSelected: false },
     { name: 'total_deposits', label: 'Total Deposits', isSelected: false },
     {
       name: 'total_estimated_withdrawals',


### PR DESCRIPTION
### **User description**
## Raw status is mention twice in operators table editor


___

### **PR Type**
Bug fix


___

### **Description**
- Removed a duplicate entry for `raw_status` in the `AVAILABLE_COLUMNS` array within the `tables.ts` file, resolving an issue where 'Raw Status' was mentioned twice in the operators table editor.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tables.ts</strong><dd><code>Remove duplicate 'raw_status' entry from AVAILABLE_COLUMNS</code></dd></summary>
<hr>

explorer/src/constants/tables.ts

<li>Removed duplicate entry for <code>raw_status</code> in the <code>AVAILABLE_COLUMNS</code> array.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/829/files#diff-ffef1ceabdd40e5b9bc6a4456908f72fe94d4609f106473362e7693575c516cd">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

