### PR TITLE
Fix z-index issue on Nominators page

### DIFF
--- a/explorer/src/components/Staking/ActionsDropdown.tsx
+++ b/explorer/src/components/Staking/ActionsDropdown.tsx
@@ -54,13 +54,13 @@ export const ActionsDropdown: FC<ActionsDropdownProps> = ({
         })
       }
     >
-      <div className='relative z-30'>
-        <Listbox.Button className='relative w-full cursor-default rounded-full bg-primaryAccent from-primaryAccent to-purpleUndertone py-[10px] pl-3 pr-16 text-left font-["Montserrat"] text-white shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 dark:bg-gradient-to-r dark:text-white sm:text-sm md:pr-10'>
+      <div className='relative'>
+        <Listbox.Button className='bg-primaryAccent from-primaryAccent relative w-full cursor-default rounded-full to-purpleUndertone py-[10px] pl-3 pr-16 text-left font-["Montserrat"] text-white shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 dark:bg-gradient-to-r dark:text-white sm:text-sm md:pr-10'>
           <div className='flex items-center justify-center'>
             <span className='ml-2 w-28 text-center text-sm'>Actions</span>
             <span className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2'>
               <ChevronDownIcon
-                className='size-5 text-white ui-open:rotate-180 dark:text-primaryAccent'
+                className='dark:text-primaryAccent size-5 text-white ui-open:rotate-180'
                 aria-hidden='true'
               />
             </span>
@@ -72,7 +72,7 @@ export const ActionsDropdown: FC<ActionsDropdownProps> = ({
           leaveFrom='opacity-100'
           leaveTo='opacity-0'
         >
-          <Listbox.Options className='absolute z-50 sticky mt-1 max-h-60 w-auto overflow-auto rounded-xl bg-white py-2 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-blueAccent dark:text-white sm:text-sm md:w-full'>
+          <Listbox.Options className='absolute sticky z-50 mt-1 max-h-60 w-auto overflow-auto rounded-xl bg-white py-2 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-blueAccent dark:text-white sm:text-sm md:w-full'>
             {actionsAvailable.map((actionType, index) => (
               <Listbox.Option
                 key={index}


### PR DESCRIPTION
### **User description**
## Fix z-index issue on Nominators page


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a `z-index` issue on the Nominators page by removing the `z-index` from the `div` wrapping the `Listbox.Button` and adjusting the `z-index` styling for `Listbox.Options`.
- Ensured that buttons from the Nominators page do not appear above the Sidekick wallet.
- Improved the consistency of class name ordering in the component.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ActionsDropdown.tsx</strong><dd><code>Fix z-index layering issue in ActionsDropdown component</code>&nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Staking/ActionsDropdown.tsx

<li>Removed <code>z-index</code> from the <code>div</code> wrapping the <code>Listbox.Button</code>.<br> <li> Adjusted <code>z-index</code> styling for <code>Listbox.Options</code> to ensure proper <br>layering.<br> <li> Minor reordering of class names for consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/831/files#diff-c87e49873837deaffbc57ef531ef0227a77f5446689b4607616410d54674902b">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

