### PR TITLE
Memoize Apollo client to avoid the client re-render (canceling request from previous client in the process)

### DIFF
--- a/explorer/src/providers/ChainProvider.tsx
+++ b/explorer/src/providers/ChainProvider.tsx
@@ -13,7 +13,7 @@ import { RetryLink } from '@apollo/client/link/retry'
 import { NetworkId } from '@autonomys/auto-utils'
 import { Indexer, defaultIndexer } from 'constants/indexers'
 import Cookies from 'js-cookie'
-import { FC, ReactNode, createContext, useCallback, useState } from 'react'
+import { FC, ReactNode, createContext, useCallback, useMemo, useState } from 'react'
 
 export type ChainContextValue = {
   indexerSet: Indexer
@@ -49,10 +49,14 @@ export const SelectedChainProvider: FC<SelectedChainProps> = ({ indexerSet, chil
     },
   })
 
-  const client = new ApolloClient({
-    link: ApolloLink.from([new RetryLink(), httpLink]),
-    cache: new InMemoryCache(),
-  })
+  const client = useMemo(
+    () =>
+      new ApolloClient({
+        link: ApolloLink.from([new RetryLink(), httpLink]),
+        cache: new InMemoryCache(),
+      }),
+    [httpLink],
+  )
 
   return <ApolloProvider client={client}>{children}</ApolloProvider>
 }


### PR DESCRIPTION
### **User description**
## Memoize Apollo client to avoid the client re-render (canceling request from previous client in the process)

This will be noticeable on an account details page for example with the first graphql query being canceled due to the search parameters getting detected and generating a re-render of the whole components tree un-memoized.


___

### **PR Type**
enhancement


___

### **Description**
- Memoized the Apollo client using `useMemo` to prevent unnecessary re-renders, which can cancel requests from the previous client.
- Ensured the Apollo client is only recreated when the `httpLink` changes, improving performance and stability.
- Updated imports to include `useMemo` from React.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChainProvider.tsx</strong><dd><code>Memoize Apollo client to prevent unnecessary re-renders</code>&nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/providers/ChainProvider.tsx

<li>Added <code>useMemo</code> to memoize the Apollo client instance.<br> <li> Prevents unnecessary re-renders by ensuring the client is only <br>recreated when <code>httpLink</code> changes.<br> <li> Imports <code>useMemo</code> from React to support memoization.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/833/files#diff-a55a9b593552c3724c0ea05e726001ec210930c00c73a6549093b80abe4f7ced">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

