### PR TITLE
Add feature flags based on networks

### DIFF
--- a/explorer/src/app/[chain]/autoid/page.tsx
+++ b/explorer/src/app/[chain]/autoid/page.tsx
@@ -1,6 +1,8 @@
-import { AutoIdPage } from '@/components/AutoId'
+import { AutoIdPage } from 'components/AutoId'
+import { NotFound } from 'components/layout/NotFound'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
+import { Routes, ROUTES } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
@@ -22,8 +24,11 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC = () => {
-  return <AutoIdPage />
+const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
+  const parent = ROUTES.find((item) => item.name === Routes.domains)
+  const item = parent && parent.children?.find((item) => item.name === Routes.autoid)
+  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <AutoIdPage />
+  return <NotFound />
 }
 
 export default Page

--- a/explorer/src/app/[chain]/autoid/page.tsx
+++ b/explorer/src/app/[chain]/autoid/page.tsx
@@ -2,10 +2,11 @@ import { AutoIdPage } from 'components/AutoId'
 import { NotFound } from 'components/layout/NotFound'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
-import { Routes, ROUTES } from 'constants/routes'
+import { Routes } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
+import { isRouteSupportingNetwork } from 'utils/route'
 
 export async function generateMetadata({ params: { chain } }: ChainPageProps): Promise<Metadata> {
   const chainTitle = indexers.find((c) => c.network === chain)?.title || 'Unknown chain'
@@ -24,11 +25,7 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
-  const parent = ROUTES.find((item) => item.name === Routes.domains)
-  const item = parent && parent.children?.find((item) => item.name === Routes.autoid)
-  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <AutoIdPage />
-  return <NotFound />
-}
+const Page: FC<ChainPageProps> = ({ params: { chain } }) =>
+  isRouteSupportingNetwork(chain, Routes.domains, Routes.autoid) ? <AutoIdPage /> : <NotFound />
 
 export default Page

--- a/explorer/src/app/[chain]/domains/[domainId]/page.tsx
+++ b/explorer/src/app/[chain]/domains/[domainId]/page.tsx
@@ -1,6 +1,8 @@
 import { Domain } from 'components/Domain/Domain'
+import { NotFound } from 'components/layout/NotFound'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
+import { Routes, ROUTES } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { AccountIdPageProps, ChainPageProps } from 'types/app'
@@ -24,8 +26,10 @@ export async function generateMetadata({
   }
 }
 
-const Page: FC = () => {
-  return <Domain />
+const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
+  const item = ROUTES.find((item) => item.name === Routes.domains)
+  if (chain && item && item.networks?.includes(chain)) return <Domain />
+  return <NotFound />
 }
 
 export default Page

--- a/explorer/src/app/[chain]/domains/page.tsx
+++ b/explorer/src/app/[chain]/domains/page.tsx
@@ -1,6 +1,8 @@
 import { DomainPage } from 'components/Domain'
+import { NotFound } from 'components/layout/NotFound'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
+import { Routes, ROUTES } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
@@ -22,8 +24,10 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC = () => {
-  return <DomainPage />
+const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
+  const item = ROUTES.find((item) => item.name === Routes.domains)
+  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <DomainPage />
+  return <NotFound />
 }
 
 export default Page

--- a/explorer/src/app/[chain]/domains/page.tsx
+++ b/explorer/src/app/[chain]/domains/page.tsx
@@ -2,10 +2,11 @@ import { DomainPage } from 'components/Domain'
 import { NotFound } from 'components/layout/NotFound'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
-import { Routes, ROUTES } from 'constants/routes'
+import { Routes } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
+import { isRouteSupportingNetwork } from 'utils/route'
 
 export async function generateMetadata({ params: { chain } }: ChainPageProps): Promise<Metadata> {
   const chainTitle = indexers.find((c) => c.network === chain)?.title || 'Unknown chain'
@@ -24,10 +25,7 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
-  const item = ROUTES.find((item) => item.name === Routes.domains)
-  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <DomainPage />
-  return <NotFound />
-}
+const Page: FC<ChainPageProps> = ({ params: { chain } }) =>
+  isRouteSupportingNetwork(chain, Routes.domains) ? <DomainPage /> : <NotFound />
 
 export default Page

--- a/explorer/src/app/[chain]/nova/page.tsx
+++ b/explorer/src/app/[chain]/nova/page.tsx
@@ -1,6 +1,8 @@
-import { NovaPage } from '@/components/Nova'
+import { NotFound } from 'components/layout/NotFound'
+import { NovaPage } from 'components/Nova'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
+import { Routes, ROUTES } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
@@ -22,8 +24,11 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC = () => {
-  return <NovaPage />
+const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
+  const parent = ROUTES.find((item) => item.name === Routes.domains)
+  const item = parent && parent.children?.find((item) => item.name === Routes.nova)
+  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <NovaPage />
+  return <NotFound />
 }
 
 export default Page

--- a/explorer/src/app/[chain]/nova/page.tsx
+++ b/explorer/src/app/[chain]/nova/page.tsx
@@ -2,10 +2,11 @@ import { NotFound } from 'components/layout/NotFound'
 import { NovaPage } from 'components/Nova'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
-import { Routes, ROUTES } from 'constants/routes'
+import { Routes } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
+import { isRouteSupportingNetwork } from 'utils/route'
 
 export async function generateMetadata({ params: { chain } }: ChainPageProps): Promise<Metadata> {
   const chainTitle = indexers.find((c) => c.network === chain)?.title || 'Unknown chain'
@@ -24,11 +25,7 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
-  const parent = ROUTES.find((item) => item.name === Routes.domains)
-  const item = parent && parent.children?.find((item) => item.name === Routes.nova)
-  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <NovaPage />
-  return <NotFound />
-}
+const Page: FC<ChainPageProps> = ({ params: { chain } }) =>
+  isRouteSupportingNetwork(chain, Routes.domains, Routes.nova) ? <NovaPage /> : <NotFound />
 
 export default Page

--- a/explorer/src/app/[chain]/staking/[operatorId]/page.tsx
+++ b/explorer/src/app/[chain]/staking/[operatorId]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
 
 const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
   const item = ROUTES.find((item) => item.name === Routes.staking)
-  if (chain && item && item.networks?.includes(chain)) return <Operator />
+  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <Operator />
   return <NotFound />
 }
 

--- a/explorer/src/app/[chain]/staking/[operatorId]/page.tsx
+++ b/explorer/src/app/[chain]/staking/[operatorId]/page.tsx
@@ -1,6 +1,8 @@
-import { Operator } from '@/components/Staking/Operator'
+import { NotFound } from 'components/layout/NotFound'
+import { Operator } from 'components/Staking/Operator'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
+import { Routes, ROUTES } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { AccountIdPageProps, ChainPageProps } from 'types/app'
@@ -24,8 +26,10 @@ export async function generateMetadata({
   }
 }
 
-const Page: FC = () => {
-  return <Operator />
+const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
+  const item = ROUTES.find((item) => item.name === Routes.staking)
+  if (chain && item && item.networks?.includes(chain)) return <Operator />
+  return <NotFound />
 }
 
 export default Page

--- a/explorer/src/app/[chain]/staking/[operatorId]/page.tsx
+++ b/explorer/src/app/[chain]/staking/[operatorId]/page.tsx
@@ -2,10 +2,11 @@ import { NotFound } from 'components/layout/NotFound'
 import { Operator } from 'components/Staking/Operator'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
-import { Routes, ROUTES } from 'constants/routes'
+import { Routes } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { AccountIdPageProps, ChainPageProps } from 'types/app'
+import { isRouteSupportingNetwork } from 'utils/route'
 
 export async function generateMetadata({
   params: { chain, accountId },
@@ -26,10 +27,7 @@ export async function generateMetadata({
   }
 }
 
-const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
-  const item = ROUTES.find((item) => item.name === Routes.staking)
-  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <Operator />
-  return <NotFound />
-}
+const Page: FC<ChainPageProps> = ({ params: { chain } }) =>
+  isRouteSupportingNetwork(chain, Routes.staking) ? <Operator /> : <NotFound />
 
 export default Page

--- a/explorer/src/app/[chain]/staking/nominations/page.tsx
+++ b/explorer/src/app/[chain]/staking/nominations/page.tsx
@@ -2,10 +2,11 @@ import { NotFound } from 'components/layout/NotFound'
 import { NominationsTable } from 'components/Staking/NominationsTable'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
-import { Routes, ROUTES } from 'constants/routes'
+import { Routes } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
+import { isRouteSupportingNetwork } from 'utils/route'
 
 export async function generateMetadata({ params: { chain } }: ChainPageProps): Promise<Metadata> {
   const chainTitle = indexers.find((c) => c.network === chain)?.title || 'Unknown chain'
@@ -24,11 +25,7 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
-  const item = ROUTES.find((item) => item.name === Routes.staking)
-  if (chain && item && (!item.networks || item.networks?.includes(chain)))
-    return <NominationsTable />
-  return <NotFound />
-}
+const Page: FC<ChainPageProps> = ({ params: { chain } }) =>
+  isRouteSupportingNetwork(chain, Routes.staking) ? <NominationsTable /> : <NotFound />
 
 export default Page

--- a/explorer/src/app/[chain]/staking/nominations/page.tsx
+++ b/explorer/src/app/[chain]/staking/nominations/page.tsx
@@ -26,7 +26,8 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
 
 const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
   const item = ROUTES.find((item) => item.name === Routes.staking)
-  if (chain && item && item.networks?.includes(chain)) return <NominationsTable />
+  if (chain && item && (!item.networks || item.networks?.includes(chain)))
+    return <NominationsTable />
   return <NotFound />
 }
 

--- a/explorer/src/app/[chain]/staking/nominations/page.tsx
+++ b/explorer/src/app/[chain]/staking/nominations/page.tsx
@@ -1,6 +1,8 @@
-import { NominationsTable } from '@/components/Staking/NominationsTable'
+import { NotFound } from 'components/layout/NotFound'
+import { NominationsTable } from 'components/Staking/NominationsTable'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
+import { Routes, ROUTES } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
@@ -22,8 +24,10 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC = () => {
-  return <NominationsTable />
+const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
+  const item = ROUTES.find((item) => item.name === Routes.staking)
+  if (chain && item && item.networks?.includes(chain)) return <NominationsTable />
+  return <NotFound />
 }
 
 export default Page

--- a/explorer/src/app/[chain]/staking/page.tsx
+++ b/explorer/src/app/[chain]/staking/page.tsx
@@ -1,6 +1,8 @@
-import { OperatorsList } from '@/components/Staking/OperatorsList'
+import { NotFound } from 'components/layout/NotFound'
+import { OperatorsList } from 'components/Staking/OperatorsList'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
+import { Routes, ROUTES } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
@@ -22,8 +24,10 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC = () => {
-  return <OperatorsList />
+const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
+  const item = ROUTES.find((item) => item.name === Routes.staking)
+  if (chain && item && item.networks?.includes(chain)) return <OperatorsList />
+  return <NotFound />
 }
 
 export default Page

--- a/explorer/src/app/[chain]/staking/page.tsx
+++ b/explorer/src/app/[chain]/staking/page.tsx
@@ -2,10 +2,11 @@ import { NotFound } from 'components/layout/NotFound'
 import { OperatorsList } from 'components/Staking/OperatorsList'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
-import { Routes, ROUTES } from 'constants/routes'
+import { Routes } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
+import { isRouteSupportingNetwork } from 'utils/route'
 
 export async function generateMetadata({ params: { chain } }: ChainPageProps): Promise<Metadata> {
   const chainTitle = indexers.find((c) => c.network === chain)?.title || 'Unknown chain'
@@ -24,10 +25,7 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
-  const item = ROUTES.find((item) => item.name === Routes.staking)
-  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <OperatorsList />
-  return <NotFound />
-}
+const Page: FC<ChainPageProps> = ({ params: { chain } }) =>
+  isRouteSupportingNetwork(chain, Routes.staking) ? <OperatorsList /> : <NotFound />
 
 export default Page

--- a/explorer/src/app/[chain]/staking/page.tsx
+++ b/explorer/src/app/[chain]/staking/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
 
 const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
   const item = ROUTES.find((item) => item.name === Routes.staking)
-  if (chain && item && item.networks?.includes(chain)) return <OperatorsList />
+  if (chain && item && (!item.networks || item.networks?.includes(chain))) return <OperatorsList />
   return <NotFound />
 }
 

--- a/explorer/src/app/[chain]/staking/register/page.tsx
+++ b/explorer/src/app/[chain]/staking/register/page.tsx
@@ -1,7 +1,10 @@
+import { NotFound } from 'components/layout/NotFound'
 import { RegisterOperators } from 'components/Staking/RegisterOperators'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
+import { Routes, ROUTES } from 'constants/routes'
 import { Metadata } from 'next'
+import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
 
 export async function generateMetadata({ params: { chain } }: ChainPageProps): Promise<Metadata> {
@@ -21,6 +24,10 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-export default async function Page() {
-  return <RegisterOperators />
+const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
+  const item = ROUTES.find((item) => item.name === Routes.staking)
+  if (chain && item && item.networks?.includes(chain)) return <RegisterOperators />
+  return <NotFound />
 }
+
+export default Page

--- a/explorer/src/app/[chain]/staking/register/page.tsx
+++ b/explorer/src/app/[chain]/staking/register/page.tsx
@@ -26,7 +26,8 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
 
 const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
   const item = ROUTES.find((item) => item.name === Routes.staking)
-  if (chain && item && item.networks?.includes(chain)) return <RegisterOperators />
+  if (chain && item && (!item.networks || item.networks?.includes(chain)))
+    return <RegisterOperators />
   return <NotFound />
 }
 

--- a/explorer/src/app/[chain]/staking/register/page.tsx
+++ b/explorer/src/app/[chain]/staking/register/page.tsx
@@ -2,10 +2,11 @@ import { NotFound } from 'components/layout/NotFound'
 import { RegisterOperators } from 'components/Staking/RegisterOperators'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
-import { Routes, ROUTES } from 'constants/routes'
+import { Routes } from 'constants/routes'
 import { Metadata } from 'next'
 import { FC } from 'react'
 import type { ChainPageProps } from 'types/app'
+import { isRouteSupportingNetwork } from 'utils/route'
 
 export async function generateMetadata({ params: { chain } }: ChainPageProps): Promise<Metadata> {
   const chainTitle = indexers.find((c) => c.network === chain)?.title || 'Unknown chain'
@@ -24,11 +25,7 @@ export async function generateMetadata({ params: { chain } }: ChainPageProps): P
   }
 }
 
-const Page: FC<ChainPageProps> = ({ params: { chain } }: ChainPageProps) => {
-  const item = ROUTES.find((item) => item.name === Routes.staking)
-  if (chain && item && (!item.networks || item.networks?.includes(chain)))
-    return <RegisterOperators />
-  return <NotFound />
-}
+const Page: FC<ChainPageProps> = ({ params: { chain } }) =>
+  isRouteSupportingNetwork(chain, Routes.staking) ? <RegisterOperators /> : <NotFound />
 
 export default Page

--- a/explorer/src/components/layout/DomainHeader.tsx
+++ b/explorer/src/components/layout/DomainHeader.tsx
@@ -2,7 +2,7 @@
 
 import { Bars3BottomRightIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
 import { LogoIcon } from 'components/icons'
-import { INTERNAL_ROUTES, Routes } from 'constants/routes'
+import { INTERNAL_ROUTES, ROUTES, Routes } from 'constants/routes'
 import useChains from 'hooks/useChains'
 import useMediaQuery from 'hooks/useMediaQuery'
 import Link from 'next/link'
@@ -19,23 +19,24 @@ export const DomainHeader = () => {
   const [isOpen, setIsOpen] = useState(false)
   const { network } = useChains()
 
-  const menuList = useMemo(
-    () => [
+  const menuList = useMemo(() => {
+    const domainsChildren = ROUTES.find((item) => item.name === Routes.domains)?.children
+    const list = [
       {
         title: 'Domains',
         link: `/${network}/${Routes.domains}`,
       },
-      {
-        title: 'Nova',
-        link: `/${network}/${Routes.nova}`,
-      },
-      {
-        title: 'Auto-ID',
-        link: `/${network}/${Routes.autoid}`,
-      },
-    ],
-    [network],
-  )
+    ]
+    if (domainsChildren)
+      for (const item of domainsChildren) {
+        if (!item.networks || item.networks?.includes(network))
+          list.push({
+            title: item.title,
+            link: `/${network}/${item.name}`,
+          })
+      }
+    return list
+  }, [network])
 
   return (
     <header className="body-font z-9 py-[30px] font-['Montserrat'] text-gray-600">

--- a/explorer/src/components/layout/NotFound/index.tsx
+++ b/explorer/src/components/layout/NotFound/index.tsx
@@ -1,12 +1,9 @@
 'use client'
 
-import Link from 'next/link'
-import { FC } from 'react'
-
-// common
 import { ArrowButton } from 'components/common/ArrowButton'
 import useChains from 'hooks/useChains'
-// layout
+import Link from 'next/link'
+import { FC } from 'react'
 import { NotFoundImage } from './NotFoundImage'
 
 export const NotFound: FC = () => {

--- a/explorer/src/components/layout/SectionHeader.tsx
+++ b/explorer/src/components/layout/SectionHeader.tsx
@@ -3,10 +3,7 @@
 import { CpuChipIcon, GlobeAltIcon, QueueListIcon, TrophyIcon } from '@heroicons/react/24/outline'
 import { WalletButton } from 'components/WalletButton'
 import { WalletSidekick } from 'components/WalletSideKick'
-// import { indexers } from 'constants/indexers'
-// import { domains } from 'constants/domains'
 import { ROUTES, Routes } from 'constants/routes'
-// import useChains from 'hooks/useChains'
 import useMediaQuery from 'hooks/useMediaQuery'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
@@ -19,21 +16,7 @@ export const SectionHeader: FC = () => {
   const { chain } = useParams<ChainParam>()
   const isDesktop = useMediaQuery('(min-width: 1024px)')
   const pathname = usePathname()
-
-  // const { push } = useRouter()
-
-  // const { setSelectedChain, selectedChain, setSelectedDomain } = useChains()
   const { actingAccount } = useWallet()
-
-  // const handleDomainSelected = useCallback(
-  //   (domain: string) => {
-  //     setSelectedDomain(domain)
-  //     if (domain === Routes.nova) setSelectedChain(domains[0])
-  //     else setSelectedChain(chains[0])
-  //     push(`/${network}/${domain}`)
-  //   },
-  //   [push, setSelectedChain, setSelectedDomain, network],
-  // )
 
   const domainIcon = useCallback((domain: (typeof ROUTES)[0], isActive: boolean) => {
     const className = `w-6 h-6 ${isActive ? 'text-white' : 'text-grayDark'} dark:text-white`
@@ -53,27 +36,29 @@ export const SectionHeader: FC = () => {
 
   const domainsOptions = useMemo(
     () =>
-      ROUTES.map((item, index) => {
-        const isActive = pathname.includes(`${chain}/${item.name}`)
-        return (
-          <div className='flex items-center text-[13px] font-semibold' key={`${item}-${index}`}>
-            <Link
-              href={`/${chain}/${item.name}`}
-              className='title-font mb-4 flex items-center font-medium text-gray-900 md:mb-0'
-            >
-              <button
-                className={
-                  isActive
-                    ? 'rounded-full bg-grayDarker px-4 py-2 text-white dark:bg-primaryAccent'
-                    : 'bg-white text-grayDark dark:bg-blueAccent dark:text-white'
-                }
+      ROUTES.filter((item) => !item.networks || (chain && item.networks?.includes(chain))).map(
+        (item, index) => {
+          const isActive = pathname.includes(`${chain}/${item.name}`)
+          return (
+            <div className='flex items-center text-[13px] font-semibold' key={`${item}-${index}`}>
+              <Link
+                href={`/${chain}/${item.name}`}
+                className='title-font mb-4 flex items-center font-medium text-gray-900 md:mb-0'
               >
-                {isDesktop ? item.title : domainIcon(item, isActive)}
-              </button>
-            </Link>
-          </div>
-        )
-      }),
+                <button
+                  className={
+                    isActive
+                      ? 'rounded-full bg-grayDarker px-4 py-2 text-white dark:bg-primaryAccent'
+                      : 'bg-white text-grayDark dark:bg-blueAccent dark:text-white'
+                  }
+                >
+                  {isDesktop ? item.title : domainIcon(item, isActive)}
+                </button>
+              </Link>
+            </div>
+          )
+        },
+      ),
     [isDesktop, pathname, chain, domainIcon],
   )
 

--- a/explorer/src/constants/routes.ts
+++ b/explorer/src/constants/routes.ts
@@ -1,3 +1,6 @@
+import { NetworkId } from '@autonomys/auto-utils'
+import { Route } from 'types/app'
+
 export enum Routes {
   consensus = 'consensus',
   farming = 'farming',
@@ -10,7 +13,7 @@ export enum Routes {
   // stake = 'stake',
 }
 
-export const ROUTES = [
+export const ROUTES: Route[] = [
   {
     name: Routes.consensus,
     title: 'Consensus Chain',
@@ -22,6 +25,7 @@ export const ROUTES = [
   {
     name: Routes.staking,
     title: 'Staking',
+    networks: [NetworkId.GEMINI_3H],
   },
   {
     name: Routes.leaderboard,
@@ -34,12 +38,15 @@ export const ROUTES = [
       {
         name: Routes.nova,
         title: 'Nova',
+        networks: [NetworkId.GEMINI_3H],
       },
       {
         name: Routes.autoid,
         title: 'Auto-ID',
+        networks: [NetworkId.GEMINI_3H],
       },
     ],
+    networks: [NetworkId.GEMINI_3H],
   },
   // Route deactivated till bugs are fixed and feature is ready
   // {

--- a/explorer/src/types/app.ts
+++ b/explorer/src/types/app.ts
@@ -28,3 +28,10 @@ export type EventIdPageProps = PageProps<EventIdParam>
 export type LogIdPageProps = PageProps<LogIdParam>
 
 export type OperatorIdPageProps = PageProps<OperatorIdParam>
+
+export type Route = {
+  name: string
+  title: string
+  networks?: NetworkId[]
+  children?: Route[]
+}

--- a/explorer/src/utils/route.ts
+++ b/explorer/src/utils/route.ts
@@ -1,0 +1,26 @@
+import { Route } from '@/types/app'
+import { NetworkId } from '@autonomys/auto-utils'
+import { ROUTES, Routes } from 'constants/routes'
+
+const findRoute = (route: Routes): Route | undefined => ROUTES.find((item) => item.name === route)
+
+const isRouteSupported = (currentNetwork: NetworkId, routeItem: Route): boolean =>
+  !!currentNetwork &&
+  !!routeItem &&
+  (!routeItem.networks || routeItem.networks.includes(currentNetwork))
+
+export const isRouteSupportingNetwork = (
+  currentNetwork: NetworkId | undefined,
+  route: Routes,
+  childRoute?: Routes,
+): boolean => {
+  const routeFound = findRoute(route)
+  if (!routeFound || !currentNetwork) return false
+
+  if (childRoute && routeFound.children) {
+    const child = routeFound.children.find((item) => item.name === childRoute)
+    return child ? isRouteSupported(currentNetwork, child) : false
+  }
+
+  return isRouteSupported(currentNetwork, routeFound)
+}


### PR DESCRIPTION
## Add feature flags based on networks

With the mainnet launch coming soon, and phase-1 won't include domains, we need a way to control what sections of Astral are available and displayed based on the current network selected.

I opted to add an optional `networks` property in the `ROUTES` constant, if networks are defined, this section and pages will only be available under these networks otherwise we serve the regular not found page