### PR TITLE
Improve Consensus Sub Query

### DIFF
--- a/indexers/db/metadata/databases/gemini_3h/tables/consensus_log_kinds.yaml
+++ b/indexers/db/metadata/databases/gemini_3h/tables/consensus_log_kinds.yaml
@@ -11,3 +11,12 @@ array_relationships:
         remote_table:
           name: logs
           schema: consensus
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - id
+        - kind
+      filter: {}
+      allow_aggregations: true
+    comment: ""

--- a/indexers/db/metadata/databases/gemini_3h/tables/consensus_logs.yaml
+++ b/indexers/db/metadata/databases/gemini_3h/tables/consensus_logs.yaml
@@ -24,12 +24,13 @@ select_permissions:
   - role: user
     permission:
       columns:
-        - index_in_block
-        - block_height
         - block_hash
+        - block_height
         - id
+        - index_in_block
         - kind
         - log_kind_id
+        - timestamp
         - value
       filter: {}
       allow_aggregations: true

--- a/indexers/gemini-3h/consensus/schema.graphql
+++ b/indexers/gemini-3h/consensus/schema.graphql
@@ -22,6 +22,7 @@ type Log @entity {
   logKindId: String! @index
   kind: String!
   value: String
+  timestamp: Date! @index
 }
 
 type Extrinsic @entity {

--- a/indexers/gemini-3h/consensus/src/mappings/db.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/db.ts
@@ -53,7 +53,8 @@ export async function createAndSaveLog(
   indexInBlock: number,
   rawKind: string,
   kind: string,
-  value: string
+  value: string,
+  timestamp: Date
 ): Promise<Log> {
   await createAndSaveLogKindIfNotExists(rawKind, kind);
 
@@ -68,6 +69,7 @@ export async function createAndSaveLog(
       logKindId: rawKind,
       kind,
       value,
+      timestamp,
     });
     await log.save();
   }

--- a/indexers/gemini-3h/consensus/src/mappings/db.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/db.ts
@@ -151,7 +151,6 @@ export async function createAndSaveExtrinsic(
   blockHeight: bigint,
   blockHash: string,
   indexInBlock: number,
-  callIndex: string,
   section: string,
   method: string,
   success: boolean,

--- a/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
@@ -14,27 +14,8 @@ import {
   calculateSpacePledged,
   getBlockAuthor,
 } from "./helper";
+import { EventHuman, EventPrimitive, ExtrinsicHuman } from "./types";
 import { stringify } from "./utils";
-
-type ExtrinsicPrimitive = {
-  callIndex: string;
-  args: any;
-};
-
-type ExtrinsicHuman = ExtrinsicPrimitive & {
-  method: string;
-  section: string;
-};
-
-type EventPrimitive = {
-  index: string;
-  data: any;
-};
-
-type EventHuman = EventPrimitive & {
-  method: string;
-  section: string;
-};
 
 export async function handleBlock(_block: SubstrateBlock): Promise<void> {
   const {
@@ -115,8 +96,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
     events,
   } = _call;
 
-  const extrinsic_human = method.toHuman() as ExtrinsicHuman;
-  const extrinsic_primitive = method.toPrimitive() as ExtrinsicPrimitive;
+  const methodToHuman = method.toHuman() as ExtrinsicHuman;
   const eventRecord = events[idx];
 
   const feeEvent = events.find(
@@ -146,15 +126,14 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
     BigInt(number.toString()),
     hash.toString(),
     idx,
-    extrinsic_primitive.callIndex,
-    extrinsic_human.section,
-    extrinsic_human.method,
+    methodToHuman.section,
+    methodToHuman.method,
     success,
     timestamp ? timestamp : new Date(0),
     BigInt(nonce.toString()),
     signer.toString(),
     signature.toString(),
-    stringify(extrinsic_human.args),
+    stringify(methodToHuman.args),
     error,
     BigInt(tip.toString()),
     fee,
@@ -188,9 +167,7 @@ export async function handleEvent(_event: SubstrateEvent): Promise<void> {
       : 0
     : 0;
   const args = extrinsic ? stringify(extrinsic.extrinsic.args) : "";
-  const extrinsicId = extrinsic
-    ? number + "-" + extrinsic.extrinsic.hash.toString()
-    : "";
+  const extrinsicId = extrinsic ? number + "-" + extrinsic.idx.toString() : "";
   const extrinsicHash = extrinsic ? extrinsic.extrinsic.hash.toString() : "";
 
   await createAndSaveEvent(

--- a/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
@@ -14,7 +14,7 @@ import {
   calculateSpacePledged,
   getBlockAuthor,
 } from "./helper";
-import { EventHuman, EventPrimitive, ExtrinsicHuman } from "./types";
+import { EventHuman, EventPrimitive, ExtrinsicHuman, LogValue } from "./types";
 import { stringify } from "./utils";
 
 export async function handleBlock(_block: SubstrateBlock): Promise<void> {
@@ -66,16 +66,19 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
       const logJson = log.toPrimitive();
       const kind = logData ? Object.keys(logData)[0] : "";
       const rawKind = logJson ? Object.keys(logJson)[0] : "";
-      const value = logJson
-        ? stringify(logJson[rawKind as keyof typeof logJson])
-        : "";
+      const _value = logJson ? logJson[rawKind as keyof typeof logJson] : "";
+      const value: LogValue =
+        Array.isArray(_value) && _value.length === 2
+          ? { data: _value[1], engine: _value[0] }
+          : { data: _value };
+
       return createAndSaveLog(
         height,
         blockHash,
         i,
         rawKind,
         kind,
-        value,
+        stringify(value),
         blockTimestamp
       );
     })

--- a/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
@@ -49,7 +49,7 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
   } = _block;
   const height = BigInt(number.toString());
   const blockHash = hash.toString();
-
+  const blockTimestamp = timestamp ? timestamp : new Date(0);
   // Get block author
   const authorId = getBlockAuthor(_block);
 
@@ -66,7 +66,7 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
   await createAndSaveBlock(
     blockHash,
     height,
-    timestamp ? timestamp : new Date(0),
+    blockTimestamp,
     parentHash.toString(),
     specVersion.toString(),
     stateRoot.toString(),
@@ -88,7 +88,15 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
       const value = logJson
         ? stringify(logJson[rawKind as keyof typeof logJson])
         : "";
-      return createAndSaveLog(height, blockHash, i, rawKind, kind, value);
+      return createAndSaveLog(
+        height,
+        blockHash,
+        i,
+        rawKind,
+        kind,
+        value,
+        blockTimestamp
+      );
     })
   );
 }

--- a/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
@@ -14,7 +14,13 @@ import {
   calculateSpacePledged,
   getBlockAuthor,
 } from "./helper";
-import { EventHuman, EventPrimitive, ExtrinsicHuman, LogValue } from "./types";
+import {
+  EventHuman,
+  EventPrimitive,
+  ExtrinsicHuman,
+  ExtrinsicPrimitive,
+  LogValue,
+} from "./types";
 import { stringify } from "./utils";
 
 export async function handleBlock(_block: SubstrateBlock): Promise<void> {
@@ -100,6 +106,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
   } = _call;
 
   const methodToHuman = method.toHuman() as ExtrinsicHuman;
+  const methodToPrimitive = method.toPrimitive() as ExtrinsicPrimitive;
   const eventRecord = events[idx];
 
   const feeEvent = events.find(
@@ -136,7 +143,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
     BigInt(nonce.toString()),
     signer.toString(),
     signature.toString(),
-    stringify(methodToHuman.args),
+    stringify(methodToPrimitive.args),
     error,
     BigInt(tip.toString()),
     fee,
@@ -169,7 +176,6 @@ export async function handleEvent(_event: SubstrateEvent): Promise<void> {
       ? eventRecord.phase.asApplyExtrinsic.toNumber()
       : 0
     : 0;
-  const args = extrinsic ? stringify(extrinsic.extrinsic.args) : "";
   const extrinsicId = extrinsic ? number + "-" + extrinsic.idx.toString() : "";
   const extrinsicHash = extrinsic ? extrinsic.extrinsic.hash.toString() : "";
 
@@ -185,6 +191,6 @@ export async function handleEvent(_event: SubstrateEvent): Promise<void> {
     timestamp ? timestamp : new Date(0),
     eventRecord ? eventRecord.phase.type : "",
     pos,
-    args
+    stringify(primitive.data)
   );
 }

--- a/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts
@@ -110,7 +110,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
         header: { number },
       },
     },
-    extrinsic: { method, hash, nonce, signer, signature, tip, args },
+    extrinsic: { method, hash, nonce, signer, signature, tip },
     success,
     events,
   } = _call;
@@ -154,7 +154,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
     BigInt(nonce.toString()),
     signer.toString(),
     signature.toString(),
-    stringify(args),
+    stringify(extrinsic_human.args),
     error,
     BigInt(tip.toString()),
     fee,

--- a/indexers/gemini-3h/consensus/src/mappings/types.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/types.ts
@@ -1,0 +1,19 @@
+type ExtrinsicPrimitive = {
+  callIndex: string;
+  args: any;
+};
+
+export type ExtrinsicHuman = ExtrinsicPrimitive & {
+  method: string;
+  section: string;
+};
+
+export type EventPrimitive = {
+  index: string;
+  data: any;
+};
+
+export type EventHuman = EventPrimitive & {
+  method: string;
+  section: string;
+};

--- a/indexers/gemini-3h/consensus/src/mappings/types.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/types.ts
@@ -17,3 +17,8 @@ export type EventHuman = EventPrimitive & {
   method: string;
   section: string;
 };
+
+export type LogValue = {
+  data: any;
+  engine?: string;
+};

--- a/indexers/gemini-3h/consensus/src/mappings/types.ts
+++ b/indexers/gemini-3h/consensus/src/mappings/types.ts
@@ -1,4 +1,4 @@
-type ExtrinsicPrimitive = {
+export type ExtrinsicPrimitive = {
   callIndex: string;
   args: any;
 };


### PR DESCRIPTION
### **User description**
## Improve Consensus Sub Query

- Add permissions for log_kind table
- Add timestamp on log table
- Change log.args to be a object with parameters key (instead a array of values)
- Move type to separate file
- Improve log value to be a object (data,engine) w/ parameters key


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Enhanced the `createAndSaveLog` function to include a `timestamp` parameter for better log tracking.
- Refactored log value handling to use an object structure with `data` and `engine` keys, improving clarity and consistency.
- Moved type definitions to a separate file for better organization and maintainability.
- Added select permissions for `log_kind` and `logs` tables, allowing users to access additional fields like `timestamp`.
- Updated GraphQL schema to include a `timestamp` field in the `Log` type, aligning with backend changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db.ts</strong><dd><code>Enhance logging and extrinsic creation functions with timestamp and </code><br><code>cleanup</code></dd></summary>
<hr>

indexers/gemini-3h/consensus/src/mappings/db.ts

<li>Added <code>timestamp</code> parameter to <code>createAndSaveLog</code> function.<br> <li> Removed <code>callIndex</code> parameter from <code>createAndSaveExtrinsic</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/865/files#diff-050a4dc666d289c9c4dfebcb20496f777023943303b45559b6a5247c8e5f7960">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mappingHandlers.ts</strong><dd><code>Refactor mapping handlers for improved logging and timestamp handling</code></dd></summary>
<hr>

indexers/gemini-3h/consensus/src/mappings/mappingHandlers.ts

<li>Imported new types from <code>types.ts</code>.<br> <li> Refactored log value to be an object with <code>data</code> and <code>engine</code> keys.<br> <li> Updated timestamp handling for blocks and extrinsics.<br> <li> Simplified extrinsic ID creation logic.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/865/files#diff-e15aa560e9d8edd4ad52cb663bcab829e1995621e219d698977b3a94150fc535">+24/-36</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Separate type definitions into a dedicated file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/gemini-3h/consensus/src/mappings/types.ts

<li>Moved type definitions for <code>ExtrinsicHuman</code>, <code>EventHuman</code>, and <code>LogValue</code> to <br>a separate file.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/865/files#diff-372e0a6a58a7fca2a3d51deb30aee5e8c64fdba43e318e2fa5cde6cd9c637149">+24/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.graphql</strong><dd><code>Extend Log type with timestamp field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/gemini-3h/consensus/schema.graphql

- Added `timestamp` field to `Log` type.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/865/files#diff-99ee9237e346c42dac8aebc8b0f8e175361cec641033fc7859ee0c2fa8afc5d0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consensus_log_kinds.yaml</strong><dd><code>Add select permissions for log_kind table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/db/metadata/databases/gemini_3h/tables/consensus_log_kinds.yaml

- Added select permissions for `log_kind` table for `user` role.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/865/files#diff-4be4c12bd1c094e4be3a4395be3c7f6acd44b4fd370de8dd9fc46ee1c3d1e8d3">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>consensus_logs.yaml</strong><dd><code>Update select permissions to include timestamp in logs</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/db/metadata/databases/gemini_3h/tables/consensus_logs.yaml

<li>Added <code>timestamp</code> to the list of selectable columns for <code>user</code> role.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/865/files#diff-95fb02c3339e361b9b484289a4a49b2519993fc6151e490c3c018b2a92a15992">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information