### PR TITLE
Fix testnet rewards label and date format

### DIFF
--- a/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
+++ b/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
@@ -44,6 +44,7 @@ type Campaign = {
   testnet: string
   icon: React.ReactNode
   dateRange?: DateRange
+  label?: string
 }
 
 const Modal: FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpen, onClose }) => {
@@ -95,6 +96,7 @@ const DEFAULT_REWARDS: Rewards = {
   },
 }
 
+const DATE_LOCALES = 'en-CA'
 const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
   year: 'numeric',
   month: 'numeric',
@@ -117,6 +119,7 @@ export const TestnetRewardsTable: FC = () => {
         name: 'aries',
         testnet: 'Aries Stress Test',
         icon: <AriesStressTestIcon />,
+        label: 'eligible addresses',
       },
       geminiI: {
         name: 'geminiI',
@@ -135,6 +138,7 @@ export const TestnetRewardsTable: FC = () => {
         testnet: 'Gemini 3',
         icon: <Gemini3TestnetIcon />,
         dateRange: { start: new Date('2023-09-06'), end: new Date('2024-07-25') },
+        label: 'block and vote rewards',
       },
       stakeWarsI: {
         name: 'stakeWarsI',
@@ -498,7 +502,7 @@ export const TestnetRewardsTable: FC = () => {
                     <td className='whitespace-nowrap px-6 py-4 text-sm text-gray-500 dark:text-gray-300'>
                       <span className='font-bold'>{userTestnetRewardsByPhase(campaign.name)}</span>
                       <br /> out of {totalTestnetByPhase(campaign.name)}{' '}
-                      {campaign.name === 'aries' ? 'eligible addresses' : 'tSSC'}
+                      {campaign.label ? campaign.label : 'tSSC'}
                     </td>
                     <td className='whitespace-nowrap px-6 py-4 text-sm text-gray-500 dark:text-gray-300'>
                       <span className='font-bold'>
@@ -512,7 +516,7 @@ export const TestnetRewardsTable: FC = () => {
                     </td>
                     <td className='whitespace-nowrap px-6 py-4 text-sm text-gray-500 dark:text-gray-300'>
                       {campaign.dateRange
-                        ? `${campaign.dateRange.start.toLocaleDateString(undefined, DATE_OPTIONS)} - ${campaign.dateRange.end.toLocaleDateString(undefined, DATE_OPTIONS)}`
+                        ? `${campaign.dateRange.start.toLocaleDateString(DATE_LOCALES, DATE_OPTIONS)} - ${campaign.dateRange.end.toLocaleDateString(DATE_LOCALES, DATE_OPTIONS)}`
                         : 'N/A'}
                     </td>
                   </tr>

--- a/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
+++ b/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
@@ -67,7 +67,7 @@ const Modal: FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpen, onClose }
 }
 
 const MAINNET_TOTAL_SUPPLY = 1000000000
-
+const MAINNET_TOKEN_SYMBOL = 'AI3'
 const PERCENTAGE_PRECISION = 6
 const DEFAULT_REWARDS: Rewards = {
   aries: {
@@ -454,7 +454,7 @@ export const TestnetRewardsTable: FC = () => {
             <div className='mx-8 flex w-full max-w-6xl items-center justify-between rounded-full border border-blue-600 bg-blue-50 p-8 text-blue-600'>
               <div className='text-2xl font-semibold'>TOTAL ALLOCATION</div>
               <div className='text-4xl font-bold'>
-                {numberFormattedString(totalUserMainnetAllocation)} ATC
+                {numberFormattedString(totalUserMainnetAllocation)} {MAINNET_TOKEN_SYMBOL}
               </div>
               <div className='text-2xl font-semibold'>TESTNETS PHASES IN TOTAL</div>
               <div className='text-4xl font-bold'>{testnetsWithRewardsCount}</div>
@@ -474,10 +474,10 @@ export const TestnetRewardsTable: FC = () => {
                     EARNINGS, tSSC
                   </th>
                   <th className='px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300'>
-                    EARNINGS, % ATC
+                    EARNINGS, % {MAINNET_TOKEN_SYMBOL}
                   </th>
                   <th className='px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300'>
-                    EARNINGS, ATC
+                    EARNINGS, {MAINNET_TOKEN_SYMBOL}
                   </th>
                   <th className='px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300'>
                     Date Range
@@ -512,7 +512,7 @@ export const TestnetRewardsTable: FC = () => {
                     </td>
                     <td className='whitespace-nowrap px-6 py-4 text-sm text-gray-500 dark:text-gray-300'>
                       {numberFormattedString(totalMainnetAllocationByPhase(campaign.name))}
-                      <br /> out of {totalMainnetByPhase(campaign.name)} tSSC
+                      <br /> out of {totalMainnetByPhase(campaign.name)} {MAINNET_TOKEN_SYMBOL}
                     </td>
                     <td className='whitespace-nowrap px-6 py-4 text-sm text-gray-500 dark:text-gray-300'>
                       {campaign.dateRange
@@ -537,7 +537,7 @@ export const TestnetRewardsTable: FC = () => {
                 {totalMainnetRewardsPercentage}
               </div>
               <div className='text-sm text-gray-500 dark:text-gray-300'>
-                {numberFormattedString(totalUserMainnetAllocation)} ATC
+                {numberFormattedString(totalUserMainnetAllocation)} {MAINNET_TOKEN_SYMBOL}
               </div>
               <div className='text-sm text-gray-500 dark:text-gray-300'></div>
               <div className='text-sm text-gray-500 dark:text-gray-300'></div>


### PR DESCRIPTION
### **User description**
## Fix testnet rewards label and date format

- Fix testnet rewards label
- Fix date format to be yyyy-mm-dd on testnet rewards


___

### **PR Type**
Bug fix


___

### **Description**
- Added a `label` property to the `Campaign` type and initialized it for specific campaigns to fix the testnet rewards label issue.
- Introduced a `DATE_LOCALES` constant to ensure consistent date formatting across the application.
- Updated the date formatting logic to use the `DATE_LOCALES` constant, ensuring the date format is `yyyy-mm-dd`.
- Modified the logic to use `campaign.label` if available, improving the flexibility of label display.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestnetRewardsTable.tsx</strong><dd><code>Fix testnet rewards label and date format issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx

<li>Added <code>label</code> property to <code>Campaign</code> type and initialized it for specific <br>campaigns.<br> <li> Introduced <code>DATE_LOCALES</code> constant for consistent date formatting.<br> <li> Updated date formatting to use <code>DATE_LOCALES</code> for <code>toLocaleDateString</code>.<br> <li> Modified logic to use <code>campaign.label</code> if available, instead of <br>hardcoded strings.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/873/files#diff-35e3074a14443524d99d3004b4fa803bb33ed43a0649f85383a66ac28bdc1e76">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information