### PR TITLE
Add ToS to the farming downloads page

### DIFF
--- a/explorer/src/components/Farming/index.tsx
+++ b/explorer/src/components/Farming/index.tsx
@@ -16,6 +16,7 @@ interface ReleaseData {
 export const DownloadPage: FC = () => {
   const [userOS, setUserOS] = useState<string | null>(null)
   const [releaseAssets, setReleaseAssets] = useState<ReleaseAsset[]>([])
+  const [isToSChecked, setIsToSChecked] = useState<boolean>(false)
 
   useEffect(() => {
     const getOS = () => {
@@ -47,6 +48,7 @@ export const DownloadPage: FC = () => {
 
   const getDownloadLink = useCallback(
     (os: string) => {
+      if (!isToSChecked) return '#'
       switch (os) {
         case 'Windows':
           return releaseAssets.find((asset) => asset.name.endsWith('.msi'))?.browser_download_url
@@ -58,7 +60,7 @@ export const DownloadPage: FC = () => {
           return '#'
       }
     },
-    [releaseAssets],
+    [isToSChecked, releaseAssets],
   )
 
   const getAssetName = useCallback(
@@ -78,8 +80,6 @@ export const DownloadPage: FC = () => {
   )
 
   const renderDownloadSection = useMemo(() => {
-    const downloadLink = getDownloadLink(userOS || '')
-
     switch (userOS) {
       case 'Windows':
         return (
@@ -92,10 +92,6 @@ export const DownloadPage: FC = () => {
               <li>RAM: 8 GB</li>
               <li>Disk Space: 100 GB</li>
             </ul>
-            <a href={downloadLink} className='btn-download mt-4'>
-              Download
-              <div className='text-sm'>Windows</div>
-            </a>
             <h3 className='mt-6 text-xl font-semibold'>Installation Instructions:</h3>
             <ol className='list-inside list-decimal text-left'>
               <li>Download the installer from the link above.</li>
@@ -115,10 +111,6 @@ export const DownloadPage: FC = () => {
               <li>RAM: 4 GB</li>
               <li>Disk Space: 500 MB</li>
             </ul>
-            <a href={downloadLink} className='btn-download mt-4'>
-              Download
-              <div className='text-sm'>macOS</div>
-            </a>
             <h3 className='mt-6 text-xl font-semibold'>Installation Instructions:</h3>
             <ol className='list-inside list-decimal text-left'>
               <li>Download the DMG file from the link above.</li>
@@ -138,10 +130,6 @@ export const DownloadPage: FC = () => {
               <li>RAM: 4 GB</li>
               <li>Disk Space: 500 MB</li>
             </ul>
-            <a href={downloadLink} className='btn-download mt-4'>
-              Download
-              <div className='text-sm'>Linux</div>
-            </a>
             <h3 className='mt-6 text-xl font-semibold'>Installation Instructions:</h3>
             <ol className='list-inside list-decimal text-left'>
               <li>Download the tar.gz file from the link above.</li>
@@ -154,22 +142,40 @@ export const DownloadPage: FC = () => {
       default:
         return <p className='text-center'>Sorry, your operating system is not supported.</p>
     }
-  }, [getDownloadLink, userOS])
+  }, [userOS])
 
   const downloadButton = useMemo(
     () => (
       <div className='mb-2 flex items-center justify-center text-center'>
         <a href={getDownloadLink(userOS || '')} className='row btn-download'>
-          <button className='relative mb-2 w-full cursor-pointer rounded-full bg-primaryAccent from-primaryAccent to-purpleUndertone py-[10px] pl-3 pr-16 text-left font-["Montserrat"] text-white shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 dark:bg-gradient-to-r dark:text-white sm:text-sm md:pr-10'>
+          <button className='relative mb-2 w-full cursor-pointer rounded-full bg-primaryAccent from-primaryAccent to-purpleUndertone py-[10px] pl-3 pr-16 text-center font-["Montserrat"] text-white shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 dark:bg-gradient-to-r dark:text-white sm:text-sm md:pr-10'>
             Download Space Acres
           </button>
+          <div className='mt-4 text-left'>
+            <label className='flex items-center'>
+              <input
+                type='checkbox'
+                checked={isToSChecked}
+                onChange={(e) => setIsToSChecked(e.target.checked)}
+              />
+              <span className='ml-2'>
+                I have read and agree to the{' '}
+                <a
+                  href='https://www.autonomys.xyz/terms-of-use'
+                  className='text-blue-500 underline'
+                >
+                  Terms of Service
+                </a>
+              </span>
+            </label>
+          </div>
           <div className='text-sm text-gray-900 dark:text-white'>
             {getAssetName(userOS || '')} for {userOS}
           </div>
         </a>
       </div>
     ),
-    [getDownloadLink, getAssetName, userOS],
+    [getDownloadLink, userOS, isToSChecked, getAssetName],
   )
 
   return (


### PR DESCRIPTION
### **User description**
## Add ToS to the farming downloads page

### Screenshot

![image](https://github.com/user-attachments/assets/aed4930b-761d-4f30-b342-3c5b2c544456)


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new state `isToSChecked` to track whether the user has agreed to the Terms of Service.
- Modified the download link logic to disable downloads unless the Terms of Service checkbox is checked.
- Added a checkbox for users to confirm they have read and agree to the Terms of Service, with a link to the terms.
- Updated the UI to reflect these changes, ensuring the download button is only active when the terms are agreed to.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add Terms of Service agreement to download process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Farming/index.tsx

<li>Added a state to track Terms of Service (ToS) agreement.<br> <li> Modified download link logic to require ToS agreement.<br> <li> Added a checkbox for users to agree to the ToS.<br> <li> Updated button and link styles and logic.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/877/files#diff-56a294ba09aa34bd7c8432524904ac828bb612a22268b3ab7388d52430f22468">+24/-18</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information