### PR TITLE
## Fix end of gem2 date range

### DIFF
--- a/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
+++ b/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
@@ -131,7 +131,7 @@ export const TestnetRewardsTable: FC = () => {
         name: 'geminiII',
         testnet: 'Gemini 2',
         icon: <GeminiIITestnetIcon />,
-        dateRange: { start: new Date('2022-09-20'), end: new Date('2023-09-06') },
+        dateRange: { start: new Date('2022-09-20'), end: new Date('2022-10-25') },
       },
       geminiIII: {
         name: 'geminiIII',


### PR DESCRIPTION
### **User description**
## Fix end of gem2 date range


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the end date for the 'geminiII' testnet in the `TestnetRewardsTable` component.
- The end date was corrected from '2023-09-06' to '2022-10-25'.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestnetRewardsTable.tsx</strong><dd><code>Fix incorrect end date for 'geminiII' date range</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx

<li>Updated the end date of the 'geminiII' date range.<br> <li> Changed end date from '2023-09-06' to '2022-10-25'.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/878/files#diff-35e3074a14443524d99d3004b4fa803bb33ed43a0649f85383a66ac28bdc1e76">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information