### PR TITLE
Fix gemini3 end date

### DIFF
--- a/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
+++ b/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
@@ -137,7 +137,7 @@ export const TestnetRewardsTable: FC = () => {
         name: 'geminiIII',
         testnet: 'Gemini 3',
         icon: <Gemini3TestnetIcon />,
-        dateRange: { start: new Date('2023-09-06'), end: new Date('2024-07-25') },
+        dateRange: { start: new Date('2023-09-06'), end: new Date('2024-09-09') },
         label: 'block and vote rewards',
       },
       stakeWarsI: {

--- a/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
+++ b/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
@@ -137,7 +137,7 @@ export const TestnetRewardsTable: FC = () => {
         name: 'geminiIII',
         testnet: 'Gemini 3',
         icon: <Gemini3TestnetIcon />,
-        dateRange: { start: new Date('2023-09-06'), end: new Date('2024-09-09') },
+        dateRange: { start: new Date('2023-09-06'), end: new Date('2024-09-18') },
         label: 'block and vote rewards',
       },
       stakeWarsI: {


### PR DESCRIPTION
### **User description**
## Fix gemini3 end date


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected the end date for the `geminiIII` testnet in the `TestnetRewardsTable` component.
- Updated the date range to ensure accurate representation of the testnet period.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestnetRewardsTable.tsx</strong><dd><code>Fix incorrect end date for Gemini III testnet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx

<li>Updated the end date for the <code>geminiIII</code> testnet.<br> <li> Changed end date from <code>2024-07-25</code> to <code>2024-09-09</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/889/files#diff-35e3074a14443524d99d3004b4fa803bb33ed43a0649f85383a66ac28bdc1e76">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information