### PR TITLE
Add a fix for old event that don't have amount arg

### DIFF
--- a/indexers/gemini-3h/leaderboard/src/mappings/mappingHandlers.ts
+++ b/indexers/gemini-3h/leaderboard/src/mappings/mappingHandlers.ts
@@ -310,10 +310,19 @@ export async function handleOperatorNominatedEvent(
     event: {
       data: [_operatorId, _nominatorId, _amount],
     },
+    extrinsic,
   } = event;
+  const method = extrinsic?.extrinsic.method.toPrimitive() as {
+    args: {
+      operator_id: number;
+      amount: string;
+    };
+  };
   const operatorId = _operatorId.toString();
   const nominatorId = _nominatorId.toString();
-  const amount = BigInt(_amount.toString());
+  const amount = _amount
+    ? BigInt(_amount.toString())
+    : BigInt(method.args.amount);
   const blockNumber = event.block.block.header.number.toNumber();
   const timestamp = event.block.timestamp ?? new Date(0);
 


### PR DESCRIPTION
### **User description**
## Add a fix for old event that don't have amount arg

Some older event on gemini-3h don't have a amount argument, if it's the case we take it from extrinsic method args


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug where older events in `gemini-3h` did not have the `amount` argument.
- Implemented a fallback to retrieve `amount` from `extrinsic` method arguments when missing.
- Ensured the `handleOperatorNominatedEvent` function can process both old and new event formats.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mappingHandlers.ts</strong><dd><code>Fix missing amount argument in old events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/gemini-3h/leaderboard/src/mappings/mappingHandlers.ts

<li>Added handling for missing <code>_amount</code> in event data.<br> <li> Fallback to <code>amount</code> from <code>extrinsic</code> method arguments if <code>_amount</code> is not <br>present.<br> <li> Ensured compatibility with older events lacking the <code>amount</code> argument.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/892/files#diff-e06b686b3bd506cde846e81afa6f95457b53e7891f4c4fe99ac1a3ba4164ff2f">+10/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information