### PR TITLE
Add Taurus Indexers Part Two

### DIFF
--- a/.env
+++ b/.env
@@ -6,12 +6,15 @@ DB_PASSWORD=postgres
 DB_PORT=5432
 DB_HOST=postgres
 
+TAURUS_RPC="wss://rpc.taurus.subspace.foundation/ws"
 GEMINI_3H_RPC="ws://caddy:8000,wss://rpc-squids.gemini-3h.subspace.network/ws"
 GEMINI_3G_RPC="wss://rpc-0.gemini-3g.subspace.network/ws"
 
+TAURUS_CHAIN_ID="0x295aeafca762a304d92ee1505548695091f6082d3f0aa4d092ac3cd6397a6c5e"
 GEMINI_3H_CHAIN_ID="0x0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
 GEMINI_3G_CHAIN_ID="0x418040fc282f5e5ddd432c46d05297636f6f75ce68d66499ff4cbda69ccd180b"
 
+DB_TAURUS=taurus
 DB_GEMINI_3H=gemini_3h
 
 DB_GEMINI_3G_TESTNET_REWARDS=gemini_3g_testnet_rewards

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,6 +19,18 @@ services:
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
 
+  taurus_dictionary_subquery_node:
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+
+  taurus_dictionary_graphql_engine:
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+
   gemini_3h_dictionary_subquery_node:
     logging:
       driver: loki

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,59 @@ services:
       - graphql-engine
       - serve
 
+  # Taurus Dictionary
+  taurus_dictionary_subquery_node:
+    profiles: [dictionary, taurus, taurus_dictionary]
+    build:
+      context: ./indexers/dictionary/autonomys-taurus
+    depends_on:
+      "node":
+        condition: service_healthy
+      "postgres":
+        condition: service_healthy
+    restart: unless-stopped
+    environment:
+      DB_USER: ${DB_USER}
+      DB_PASS: ${DB_PASSWORD}
+      DB_DATABASE: ${DB_TAURUS}
+      DB_HOST: ${DB_HOST}
+      DB_PORT: 5432
+    volumes:
+      - ./indexers/dictionary/autonomys-taurus:/dictionary
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://taurus_dictionary_subquery_node:3000/ready",
+        ]
+      interval: 3s
+      timeout: 5s
+      retries: 10
+    command:
+      - -f=/dictionary
+      - --disable-historical=true
+
+  taurus_dictionary_graphql_engine:
+    profiles: [dictionary, taurus, taurus_dictionary]
+    image: onfinality/subql-query:latest
+    ports:
+      - "${TAURUS_DICTIONARY_SUBQUERY_NODE_PORT}:3000"
+    depends_on:
+      - "postgres"
+      - "taurus_dictionary_subquery_node"
+    restart: unless-stopped
+    environment:
+      DB_USER: ${DB_USER}
+      DB_PASS: ${DB_PASSWORD}
+      DB_DATABASE: ${DB_TAURUS}
+      DB_HOST: ${DB_HOST}
+      DB_PORT: 5432
+    command:
+      - --name=dictionary
+      - --playground
+
   # Gemini 3H Dictionary
   gemini_3h_dictionary_subquery_node:
     profiles: [dictionary, gemini_3h, gemini_3h_dictionary]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,8 @@ services:
       # Security and Authorization
       HASURA_GRAPHQL_ENABLE_ALLOWLIST: "false" # Disable query allowlisting
 
+      # Taurus Database
+      HASURA_GRAPHQL_TAURUS_DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:5432/${DB_TAURUS}
       # Gemini 3H Databases
       HASURA_GRAPHQL_GEMINI_3H_DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:5432/${DB_GEMINI_3H}
       # Gemini 3G Database

--- a/indexers/db/docker-entrypoint-initdb.d/init-db.sql
+++ b/indexers/db/docker-entrypoint-initdb.d/init-db.sql
@@ -1,3 +1,8 @@
+CREATE DATABASE taurus;
+
+\c taurus
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
 CREATE DATABASE gemini_3h;
 
 \c gemini_3h


### PR DESCRIPTION
## Add Taurus Indexers Part Two

- cd indexers/dictionary && git fetch origin testnet
- git checkout testnet && git pull origin testnet && cd ../..
- Commit the updated submodule commit hash
- Add in docker-compose and docker-compose.prod the new dictionary (node and graphql_engine)
- Add in .env <network-name>RPC , <network-name>_CHAIN_ID and DB_<new-table> (make sure the 2 dictionary service use that db)
- In indexers/db/docker-entrypoint-initdb.d/init-db.sql add the new db and enable btree_gist
- Add in docker-compose hasura service HASURA_GRAPHQL_<new-network>_DATABASE_URL using DB_<new-table>

