### PR TITLE
fix postgres path for indexer

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     volumes:
       - type: bind
-        source: /home/ubuntu/postgresql/conf/postgresql.conf
+        source: /home/ubuntu/subql/postgresql/conf/postgresql.conf
         target: /etc/postgresql/postgresql.conf
         read_only: true
     logging:


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the PostgreSQL configuration file path in the `docker-compose.prod.yml` to ensure the correct file is used.
- Changed the source path to include `subql` in the directory structure.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.prod.yml</strong><dd><code>Update PostgreSQL configuration file path in Docker Compose</code></dd></summary>
<hr>

docker-compose.prod.yml

<li>Updated the source path for the PostgreSQL configuration file.<br> <li> Changed path from <code>/home/ubuntu/postgresql/conf/postgresql.conf</code> to <br><code>/home/ubuntu/subql/postgresql/conf/postgresql.conf</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/901/files#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information