### PR TITLE
Prevent indexing too close to the head of the chain

### DIFF
--- a/indexers/taurus/consensus/src/mappings/helper.ts
+++ b/indexers/taurus/consensus/src/mappings/helper.ts
@@ -1,5 +1,5 @@
-import { account } from "@autonomys/auto-consensus";
-import { stringify } from "@autonomys/auto-utils";
+import { account, blockNumber } from "@autonomys/auto-consensus";
+import { ApiPromise, stringify } from "@autonomys/auto-utils";
 import { SubstrateBlock } from "@subql/types";
 import { request } from "http";
 import { decodeLog } from "./utils";
@@ -68,4 +68,21 @@ export const consensusUniqueRowsMapping = async (blockNumber: bigint) => {
   });
   req.write(postData);
   req.end();
+};
+
+export const preventIndexingTooCloseToTheHeadOfTheChain = async (
+  indexingBlockHeight: number | bigint
+) => {
+  if (!unsafeApi) throw new Error("Unsafe API not found");
+  if (
+    typeof indexingBlockHeight !== "number" &&
+    typeof indexingBlockHeight !== "bigint"
+  )
+    throw new Error("Indexing block height must be a number or bigint");
+  if (typeof indexingBlockHeight === "number")
+    indexingBlockHeight = BigInt(indexingBlockHeight);
+
+  const targetHeight = await blockNumber(unsafeApi as unknown as ApiPromise);
+  if (indexingBlockHeight < BigInt(targetHeight - 100))
+    throw new Error("Indexing too close to the head of the chain, skipping...");
 };

--- a/indexers/taurus/consensus/src/mappings/helper.ts
+++ b/indexers/taurus/consensus/src/mappings/helper.ts
@@ -83,6 +83,6 @@ export const preventIndexingTooCloseToTheHeadOfTheChain = async (
     indexingBlockHeight = BigInt(indexingBlockHeight);
 
   const targetHeight = await blockNumber(unsafeApi as unknown as ApiPromise);
-  if (indexingBlockHeight < BigInt(targetHeight - 100))
+  if (indexingBlockHeight > BigInt(targetHeight - 100))
     throw new Error("Indexing too close to the head of the chain, skipping...");
 };


### PR DESCRIPTION
### **User description**
## Prevent indexing too close to the head of the chain

If the current block being indexed is less than 100 blocks from the head of the chain, we throw an error, forcing the indexer worker to bail on this set of blocks and re-spawn, this is a dirty fix but will prevent the index too close to the head.


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Added a new helper function `preventIndexingTooCloseToTheHeadOfTheChain` to prevent indexing when the block height is too close to the head of the chain.
- Integrated the new function into block, call, and event handlers to ensure indexing is skipped if within 100 blocks of the chain head.
- Improved error handling by throwing errors when conditions for indexing are not met.
- Enhanced the logic to convert block height to `BigInt` for consistency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helper.ts</strong><dd><code>Add function to prevent indexing near chain head</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/taurus/consensus/src/mappings/helper.ts

<li>Added <code>preventIndexingTooCloseToTheHeadOfTheChain</code> function.<br> <li> Included <code>blockNumber</code> and <code>ApiPromise</code> imports.<br> <li> Implemented logic to prevent indexing close to the head of the chain.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/903/files#diff-f0ffacaa27f2236bc750ead02caf99cd374df87d2a9102a7250742856250fb02">+19/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mappingHandlers.ts</strong><dd><code>Integrate indexing prevention in mapping handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/taurus/consensus/src/mappings/mappingHandlers.ts

<li>Integrated <code>preventIndexingTooCloseToTheHeadOfTheChain</code> function in <br>block, call, and event handlers.<br> <li> Added height conversion to <code>BigInt</code>.<br> <li> Ensured indexing is skipped if too close to the chain head.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/903/files#diff-3086b8218297f23584fbf57779c7f481b6232a502cc3bfa52ae3a2e57f0ba920">+13/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information