### PR TITLE
Gate send token for testnet only

### DIFF
--- a/explorer/src/components/WalletSideKick/ActionsButtons.tsx
+++ b/explorer/src/components/WalletSideKick/ActionsButtons.tsx
@@ -1,3 +1,5 @@
+import useChains from '@/hooks/useChains'
+import { NetworkId } from '@autonomys/auto-utils'
 import {
   AdjustmentsVerticalIcon,
   LockClosedIcon,
@@ -18,6 +20,7 @@ interface ActionsButtonsProps {
 
 export const ActionsButtons: FC<ActionsButtonsProps> = ({ tokenSymbol }) => {
   const { subspaceAccount } = useWallet()
+  const { network } = useChains()
   const [isOpen, setIsOpen] = useState(false)
   const [action, setAction] = useState<WalletAction>(WalletAction.None)
 
@@ -40,14 +43,17 @@ export const ActionsButtons: FC<ActionsButtonsProps> = ({ tokenSymbol }) => {
 
   return (
     <div className='flex items-center justify-center gap-3'>
-      <Tooltip text={`Send ${tokenSymbol}`}>
-        <button
-          onClick={onSendToken}
-          className='m-2 flex cursor-default items-center justify-center rounded-full bg-primaryAccent p-2'
-        >
-          <PaperAirplaneIcon className='w-8 text-white' />
-        </button>
-      </Tooltip>
+      {/* TODO: Remove this once Mainnet is supporting tokens transfer */}
+      {network === NetworkId.TAURUS && (
+        <Tooltip text={`Send ${tokenSymbol}`}>
+          <button
+            onClick={onSendToken}
+            className='m-2 flex cursor-default items-center justify-center rounded-full bg-primaryAccent p-2'
+          >
+            <PaperAirplaneIcon className='w-8 text-white' />
+          </button>
+        </Tooltip>
+      )}
       <Tooltip text={`Receive ${tokenSymbol}`}>
         <button
           onClick={onReceiveToken}


### PR DESCRIPTION
### **User description**
## Gate send token for testnet only


___

### **PR Type**
enhancement


___

### **Description**
- Added a condition to restrict the display of the send token button to the testnet environment only.
- Imported `useChains` and `NetworkId` to facilitate network checks.
- Wrapped the send token button with a network check to ensure it is only available on the testnet.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ActionsButtons.tsx</strong><dd><code>Restrict token transfer button to testnet environment</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/WalletSideKick/ActionsButtons.tsx

<li>Added import for <code>useChains</code> and <code>NetworkId</code>.<br> <li> Introduced a condition to display the send token button only for the <br>testnet.<br> <li> Wrapped the send token button with a network check for <br><code>NetworkId.TAURUS</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/912/files#diff-2d9ca35eb3d666ae28e3255daaf3fd79dcafa7ea4f47f744913cd9f397c4ddf3">+14/-8</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information