### PR TITLE
Fix timestamp to local time

### DIFF
--- a/explorer/src/app/[chain]/consensus/accounts/[accountId]/image/route.tsx
+++ b/explorer/src/app/[chain]/consensus/accounts/[accountId]/image/route.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable react/no-unknown-property */
+import { utcToLocalRelativeTime } from '@/utils/time'
 import { QUERY_ACCOUNT_BY_ID } from 'components/Consensus/Account/query'
 import { DocIcon, WalletIcon } from 'components/icons'
 import { TOKEN } from 'constants/general'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { AccountByIdQuery } from 'gql/graphql'
 import { notFound } from 'next/navigation'
 import { ImageResponse } from 'next/og'
@@ -64,8 +63,6 @@ function Screen({
   accountId: string
   accountById: AccountByIdQuery['consensus_accounts'][number]
 }) {
-  dayjs.extend(relativeTime)
-
   const account = {
     total: accountById?.total ?? '0',
     free: accountById?.free ?? '0',
@@ -178,7 +175,7 @@ function Screen({
                   }}
                   tw='absolute text-xl text-white p-4 ml-30 mt-16 font-bold'
                 >
-                  {dayjs(lastExtrinsic.timestamp).fromNow(true) + ' ago'}
+                  {utcToLocalRelativeTime(lastExtrinsic.timestamp)}
                 </span>
               </div>
             ) : (

--- a/explorer/src/app/[chain]/image/route.tsx
+++ b/explorer/src/app/[chain]/image/route.tsx
@@ -10,8 +10,6 @@ import {
 } from 'components/icons'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { HomeQueryQuery } from 'gql/graphql'
 import { notFound } from 'next/navigation'
 import { ImageResponse } from 'next/og'
@@ -62,8 +60,6 @@ function Screen({
   chainMatch: (typeof indexers)[number]
   data: HomeQueryQuery
 }) {
-  dayjs.extend(relativeTime)
-
   return (
     <div
       tw='relative w-full h-full flex flex-col items-center justify-between'

--- a/explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx
@@ -7,7 +7,6 @@ import { StatusIcon } from 'components/common/StatusIcon'
 import { NotFound } from 'components/layout/NotFound'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import dayjs from 'dayjs'
 import {
   ExtrinsicsByAccountIdQuery,
   ExtrinsicsByAccountIdQueryVariables,
@@ -24,6 +23,7 @@ import type { Cell } from 'types/table'
 import { downloadFullData } from 'utils/downloadFullData'
 import { shortString } from 'utils/string'
 import { countTablePages } from 'utils/table'
+import { utcToLocalRelativeTime } from 'utils/time'
 import { QUERY_ACCOUNT_EXTRINSICS } from './query'
 
 type Props = {
@@ -129,7 +129,7 @@ export const AccountExtrinsicList: FC<Props> = ({ accountId }) => {
         enableSorting: true,
         cell: ({ row }) => (
           <div key={`${row.original.id}-extrinsic-time-${row.index}`}>
-            {dayjs(row.original.timestamp).fromNow(true)}
+            {utcToLocalRelativeTime(row.original.timestamp)}
           </div>
         ),
       },

--- a/explorer/src/components/Consensus/Account/AccountGraphs.tsx
+++ b/explorer/src/components/Consensus/Account/AccountGraphs.tsx
@@ -1,12 +1,8 @@
 import { Tab } from 'components/common/Tabs'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { AccountByIdQuery } from 'gql/graphql'
 import { FC } from 'react'
 import { AccountBalanceStats } from './AccountBalanceStats'
 import { AccountGraphTabs } from './AccountGraphTabs'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   account: AccountByIdQuery['consensus_accounts'][number] | undefined

--- a/explorer/src/components/Consensus/Account/AccountLatestRewards.tsx
+++ b/explorer/src/components/Consensus/Account/AccountLatestRewards.tsx
@@ -1,7 +1,5 @@
 import { TOKEN } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { AccountByIdQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import Link from 'next/link'
@@ -9,8 +7,6 @@ import { useParams, useRouter } from 'next/navigation'
 import { FC } from 'react'
 import { AccountIdParam } from 'types/app'
 import { bigNumberToNumber } from 'utils/number'
-
-dayjs.extend(relativeTime)
 
 interface AccountLatestRewardsProps {
   isDesktop: boolean

--- a/explorer/src/components/Consensus/Account/AccountPreviousRewards.tsx
+++ b/explorer/src/components/Consensus/Account/AccountPreviousRewards.tsx
@@ -1,13 +1,9 @@
 import { TOKEN } from 'constants/general'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { useParams } from 'next/navigation'
 import { FC, useCallback, useEffect, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { AccountIdParam } from 'types/app'
 import { formatAddress } from 'utils//formatAddress'
-
-dayjs.extend(relativeTime)
 
 interface AccountPreviousRewardsProps {
   isDesktop: boolean

--- a/explorer/src/components/Consensus/Account/AccountRewardList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardList.tsx
@@ -7,8 +7,6 @@ import { SortedTable } from 'components/common/SortedTable'
 import { Spinner } from 'components/common/Spinner'
 import { PAGE_SIZE, TOKEN } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import {
   AccountByIdQuery,
   Order_By as OrderBy,
@@ -31,11 +29,10 @@ import { downloadFullData } from 'utils/downloadFullData'
 import { bigNumberToNumber, numberWithCommas } from 'utils/number'
 import { shortString } from 'utils/string'
 import { countTablePages } from 'utils/table'
+import { utcToLocalRelativeTime } from 'utils/time'
 import { NotFound } from '../../layout/NotFound'
 import { AccountDetailsCard } from './AccountDetailsCard'
 import { QUERY_REWARDS_LIST } from './query'
-
-dayjs.extend(relativeTime)
 
 type Row = RewardsListQuery['consensus_rewards'][number]
 
@@ -138,11 +135,11 @@ export const AccountRewardList: FC = () => {
         accessorKey: 'timestamp',
         header: 'Time',
         enableSorting: true,
-        cell: ({ row }: Cell<Row>) => {
-          const blockDate = dayjs(row.original.timestamp).fromNow(true)
-
-          return <div key={`${row.original.id}-block-time`}>{blockDate}</div>
-        },
+        cell: ({ row }: Cell<Row>) => (
+          <div key={`${row.original.id}-block-time`}>
+            {utcToLocalRelativeTime(row.original.timestamp)}
+          </div>
+        ),
       },
       {
         accessorKey: 'name',

--- a/explorer/src/components/Consensus/Account/AccountRewardsHistory.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardsHistory.tsx
@@ -1,13 +1,9 @@
 import { Tab } from 'components/common/Tabs'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { AccountByIdQuery } from 'gql/graphql'
 import { FC } from 'react'
 import { AccountLatestRewards } from './AccountLatestRewards'
 import { AccountPreviousRewards } from './AccountPreviousRewards'
 import { AccountRewardsTabs } from './AccountRewardsTabs'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   isDesktop?: boolean

--- a/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
@@ -9,8 +9,6 @@ import { Tooltip } from 'components/common/Tooltip'
 import { NotFound } from 'components/layout/NotFound'
 import { PAGE_SIZE, TOKEN } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { formatUnits } from 'ethers'
 import {
   Order_By as OrderBy,
@@ -32,8 +30,6 @@ import { bigNumberToNumber } from 'utils/number'
 import { formatExtrinsicId, shortString } from 'utils/string'
 import { countTablePages } from 'utils/table'
 import { QUERY_ACCOUNT_TRANSFERS } from './query'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   accountId: string
@@ -245,7 +241,7 @@ export const AccountTransfersList: FC<Props> = ({ accountId }) => {
         enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
           <div key={`${row.original.id}-created_at-${row.index}`}>
-            {dayjs(row.original.date).fromNow(true)} ago
+            {row.original.timestamp(row.original.date)}
           </div>
         ),
       },

--- a/explorer/src/components/Consensus/Block/BlockDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsCard.tsx
@@ -1,14 +1,11 @@
+import { utcToLocalRelativeTime, utcToLocalTime } from '@/utils/time'
 import { CopyButton } from 'components/common/CopyButton'
 import { List, StyledListItem } from 'components/common/List'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { BlockByIdQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import { FC } from 'react'
 import { shortString } from 'utils/string'
 import { BlockAuthor } from './BlockAuthor'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   block: NonNullable<BlockByIdQuery['consensus_blocks'][number]>
@@ -44,11 +41,9 @@ export const BlockDetailsCard: FC<Props> = ({ block, isDesktop = false }) => {
                 />
               </CopyButton>
             </StyledListItem>
-            <StyledListItem title='Timestamp'>
-              {dayjs(block.timestamp).format('DD MMM YYYY | HH:mm:ss(Z)')}
-            </StyledListItem>
+            <StyledListItem title='Timestamp'>{utcToLocalTime(block.timestamp)}</StyledListItem>
             <StyledListItem title='Block Time'>
-              {dayjs(block.timestamp).fromNow(true)}
+              {utcToLocalRelativeTime(block.timestamp)}
             </StyledListItem>
             <StyledListItem title='Hash'>
               <CopyButton value={block.hash} message='Hash copied'>

--- a/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
@@ -6,8 +6,6 @@ import { SortedTable } from 'components/common/SortedTable'
 import { Spinner } from 'components/common/Spinner'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { EventsByBlockIdQuery, EventsByBlockIdQueryVariables } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import { useSquidQuery } from 'hooks/useSquidQuery'
@@ -22,8 +20,6 @@ import { sort } from 'utils/sort'
 import { countTablePages } from 'utils/table'
 import { NotFound } from '../../layout/NotFound'
 import { QUERY_BLOCK_EVENTS } from './query'
-
-dayjs.extend(relativeTime)
 
 type Row = EventsByBlockIdQuery['consensus_events'][number]
 

--- a/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
@@ -1,13 +1,12 @@
 'use client'
 
+import { utcToLocalRelativeTime } from '@/utils/time'
 import type { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
 import { Spinner } from 'components/common/Spinner'
 import { StatusIcon } from 'components/common/StatusIcon'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { ExtrinsicsByBlockIdQuery, ExtrinsicsByBlockIdQueryVariables } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import { useSquidQuery } from 'hooks/useSquidQuery'
@@ -21,8 +20,6 @@ import { shortString } from 'utils/string'
 import { countTablePages } from 'utils/table'
 import { NotFound } from '../../layout/NotFound'
 import { QUERY_BLOCK_EXTRINSICS } from './query'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   isDesktop?: boolean
@@ -92,7 +89,7 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({ isDesktop = false }) => {
         enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
           <div key={`${row.index}-block-extrinsic-action`}>
-            {dayjs(row.original.timestamp).fromNow(true)}
+            {utcToLocalRelativeTime(row.original.timestamp)}
           </div>
         ),
       },

--- a/explorer/src/components/Consensus/Block/BlockDetailsLogList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsLogList.tsx
@@ -4,16 +4,12 @@ import type { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { BlockByIdQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import Link from 'next/link'
 import { FC, useMemo, useState } from 'react'
 import type { Cell } from 'types/table'
 import { countTablePages } from 'utils/table'
-
-dayjs.extend(relativeTime)
 
 type Log = NonNullable<BlockByIdQuery['consensus_blocks'][number]>['logs'][number]
 

--- a/explorer/src/components/Consensus/Block/BlockDetailsTabs.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsTabs.tsx
@@ -1,15 +1,11 @@
 import { MobileCard } from 'components/common/MobileCard'
 import { PageTabs } from 'components/common/PageTabs'
 import { Tab } from 'components/common/Tabs'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { BlockByIdQuery } from 'gql/graphql'
 import { FC } from 'react'
 import { BlockDetailsEventList } from './BlockDetailsEventList'
 import { BlockDetailsExtrinsicList } from './BlockDetailsExtrinsicList'
 import { BlockDetailsLogList } from './BlockDetailsLogList'
-
-dayjs.extend(relativeTime)
 
 type Logs = NonNullable<BlockByIdQuery['consensus_blocks'][number]>['logs']
 

--- a/explorer/src/components/Consensus/Block/BlockList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockList.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { utcToLocalRelativeTime } from '@/utils/time'
 import { CopyButton } from 'components/common/CopyButton'
 import { SearchBar } from 'components/common/SearchBar'
 import { SortedTable } from 'components/common/SortedTable'
@@ -7,8 +8,6 @@ import { Spinner } from 'components/common/Spinner'
 import { NotFound } from 'components/layout/NotFound'
 import { PAGE_SIZE, searchTypes } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { BlocksQuery, BlocksQueryVariables, Order_By as OrderBy } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import { useSquidQuery } from 'hooks/useSquidQuery'
@@ -23,8 +22,6 @@ import { shortString } from 'utils/string'
 import { countTablePages } from 'utils/table'
 import { BlockAuthor } from './BlockAuthor'
 import { QUERY_BLOCKS } from './query'
-
-dayjs.extend(relativeTime)
 
 type Row = BlocksQuery['consensus_blocks'][number]
 
@@ -101,7 +98,9 @@ export const BlockList: FC = () => {
         header: 'Time',
         enableSorting: false,
         cell: ({ row }: Cell<Row>) => (
-          <div key={`${row.index}-block-time`}>{dayjs(row.original.timestamp).fromNow(true)}</div>
+          <div key={`${row.index}-block-time`}>
+            {utcToLocalRelativeTime(row.original.timestamp)}
+          </div>
         ),
       },
       {

--- a/explorer/src/components/Consensus/Event/EventDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Event/EventDetailsCard.tsx
@@ -1,16 +1,13 @@
+import { utcToLocalRelativeTime, utcToLocalTime } from '@/utils/time'
 import { Arguments } from 'components/common/Arguments'
 import { List, StyledListItem } from 'components/common/List'
 import { NotFound } from 'components/layout/NotFound'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { EventByIdQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import Link from 'next/link'
 import { FC } from 'react'
 import { parseArgs } from 'utils/indexerParsing'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   event: EventByIdQuery['consensus_events'][number]
@@ -40,11 +37,9 @@ export const EventDetailsCard: FC<Props> = ({ event }) => {
           <div className='flex w-full flex-col gap-5 md:flex-row'>
             <div className='w-full md:flex-1'>
               <List>
-                <StyledListItem title='Timestamp'>
-                  {dayjs(event.timestamp).format('DD MMM YYYY | HH:mm:ss(Z)')}
-                </StyledListItem>
+                <StyledListItem title='Timestamp'>{utcToLocalTime(event.timestamp)}</StyledListItem>
                 <StyledListItem title='Block Time'>
-                  {dayjs(event.timestamp).fromNow(true)}
+                  {utcToLocalRelativeTime(event.timestamp)}
                 </StyledListItem>
                 <StyledListItem title='Extrinsic'>
                   {event.extrinsic ? (

--- a/explorer/src/components/Consensus/Event/EventList.tsx
+++ b/explorer/src/components/Consensus/Event/EventList.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { utcToLocalRelativeTime } from '@/utils/time'
 import { SortingState } from '@tanstack/react-table'
 import { CopyButton } from 'components/common/CopyButton'
 import { SearchBar } from 'components/common/SearchBar'
@@ -7,8 +8,6 @@ import { SortedTable } from 'components/common/SortedTable'
 import { Spinner } from 'components/common/Spinner'
 import { PAGE_SIZE, searchTypes } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { EventsQuery, EventsQueryVariables } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import { useSquidQuery } from 'hooks/useSquidQuery'
@@ -22,8 +21,6 @@ import { numberWithCommas } from 'utils/number'
 import { countTablePages } from 'utils/table'
 import { NotFound } from '../../layout/NotFound'
 import { QUERY_EVENTS } from './query'
-
-dayjs.extend(relativeTime)
 
 type Row = EventsQuery['consensus_events'][0]
 
@@ -142,7 +139,7 @@ export const EventList: FC = () => {
         accessorKey: 'timestamp',
         header: 'Time',
         enableSorting: false,
-        cell: ({ row }: Cell<Row>) => dayjs(row.original.block?.timestamp).fromNow(true),
+        cell: ({ row }: Cell<Row>) => utcToLocalRelativeTime(row.original.block?.timestamp),
       },
     ],
     [network, section],

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsCard.tsx
@@ -1,18 +1,15 @@
+import { utcToLocalRelativeTime, utcToLocalTime } from '@/utils/time'
 import { Arguments } from 'components/common/Arguments'
 import { CopyButton } from 'components/common/CopyButton'
 import { List, StyledListItem } from 'components/common/List'
 import { StatusIcon } from 'components/common/StatusIcon'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { ExtrinsicsByIdQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import Link from 'next/link'
 import { FC } from 'react'
 import { parseArgs } from 'utils/indexerParsing'
 import { shortString } from 'utils/string'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   extrinsic: NonNullable<ExtrinsicsByIdQuery['consensus_extrinsics'][number]>
@@ -43,7 +40,7 @@ export const ExtrinsicDetailsCard: FC<Props> = ({ extrinsic, isDesktop = false }
             <div className='w-full md:flex-1'>
               <List>
                 <StyledListItem title='Timestamp'>
-                  {dayjs(extrinsic.timestamp).format('DD MMM YYYY | HH:mm:ss(Z)')}
+                  {utcToLocalTime(extrinsic.timestamp)}
                 </StyledListItem>
                 <StyledListItem title='Block Number'>
                   <Link
@@ -53,7 +50,7 @@ export const ExtrinsicDetailsCard: FC<Props> = ({ extrinsic, isDesktop = false }
                   </Link>
                 </StyledListItem>
                 <StyledListItem title='Block Time'>
-                  {dayjs(extrinsic.timestamp).fromNow(true)}
+                  {utcToLocalRelativeTime(extrinsic.timestamp)}
                 </StyledListItem>
                 <StyledListItem title='Hash'>
                   <CopyButton value={extrinsic.hash} message='Hash copied'>

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsEventList.tsx
@@ -4,16 +4,12 @@ import type { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { ExtrinsicsByIdQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import Link from 'next/link'
 import { FC, useMemo, useState } from 'react'
 import type { Cell } from 'types/table'
 import { countTablePages } from 'utils/table'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   events: NonNullable<ExtrinsicsByIdQuery['consensus_extrinsics'][number]>['events']

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { utcToLocalRelativeTime } from '@/utils/time'
 import type { SortingState } from '@tanstack/react-table'
 import { CopyButton } from 'components/common/CopyButton'
 import { SearchBar } from 'components/common/SearchBar'
@@ -8,8 +9,6 @@ import { Spinner } from 'components/common/Spinner'
 import { StatusIcon } from 'components/common/StatusIcon'
 import { PAGE_SIZE, searchTypes } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { ExtrinsicsQuery, ExtrinsicsQueryVariables } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import { useSquidQuery } from 'hooks/useSquidQuery'
@@ -22,8 +21,6 @@ import { numberWithCommas } from 'utils/number'
 import { shortString } from 'utils/string'
 import { NotFound } from '../../layout/NotFound'
 import { QUERY_EXTRINSICS } from './query'
-
-dayjs.extend(relativeTime)
 
 type Row = ExtrinsicsQuery['consensus_extrinsics'][0]
 
@@ -102,7 +99,7 @@ export const ExtrinsicList: FC = () => {
         enableSorting: false,
         cell: ({ row }: Cell<Row>) => (
           <div key={`${row.index}-extrinsic-time`}>
-            {dayjs(row.original.timestamp).fromNow(true)}
+            {utcToLocalRelativeTime(row.original.timestamp)}
           </div>
         ),
       },

--- a/explorer/src/components/Consensus/Home/HomeBlockList.tsx
+++ b/explorer/src/components/Consensus/Home/HomeBlockList.tsx
@@ -3,15 +3,12 @@
 import { ArrowLongRightIcon } from '@heroicons/react/24/outline'
 import { SortedTable } from 'components/common/SortedTable'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { HomeQueryQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
 import type { Cell } from 'types/table'
-
-dayjs.extend(relativeTime)
+import { utcToLocalRelativeTime } from 'utils/time'
 
 interface HomeBlockListProps {
   data: HomeQueryQuery
@@ -58,7 +55,7 @@ export const HomeBlockList: FC<HomeBlockListProps> = ({ data }) => {
         header: 'Time',
         cell: ({ row }: Cell<Row>) => (
           <div key={`${row.index}-home-block-timestamp`}>
-            {dayjs(row.original.timestamp).fromNow(true)}
+            {utcToLocalRelativeTime(row.original.timestamp)}
           </div>
         ),
       },

--- a/explorer/src/components/Consensus/Home/HomeExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Home/HomeExtrinsicList.tsx
@@ -1,19 +1,16 @@
 'use client'
 
+import { utcToLocalRelativeTime } from '@/utils/time'
 import { ArrowLongRightIcon } from '@heroicons/react/24/outline'
 import { SortedTable } from 'components/common/SortedTable'
 import { StatusIcon } from 'components/common/StatusIcon'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { HomeQueryQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
 import type { Cell } from 'types/table'
 import { shortString } from 'utils/string'
-
-dayjs.extend(relativeTime)
 
 interface HomeExtrinsicListProps {
   data: HomeQueryQuery
@@ -62,7 +59,7 @@ export const HomeExtrinsicList: FC<HomeExtrinsicListProps> = ({ data }) => {
         header: 'Time',
         cell: ({ row }: Cell<Row>) => (
           <div key={`${row.index}-home-extrinsic-time`}>
-            {dayjs(row.original.timestamp).fromNow(true)} ago
+            {utcToLocalRelativeTime(row.original.timestamp)}
           </div>
         ),
       },

--- a/explorer/src/components/Consensus/Log/LogDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Log/LogDetailsCard.tsx
@@ -1,13 +1,9 @@
 import { Arguments } from 'components/common/Arguments'
 import { List, StyledListItem } from 'components/common/List'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { LogByIdQuery } from 'gql/graphql'
 import { FC, useMemo } from 'react'
 import { parseArgs, parseLogValue } from 'utils/indexerParsing'
 import { shortString } from 'utils/string'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   log: NonNullable<LogByIdQuery['consensus_logs'][number]>

--- a/explorer/src/components/Consensus/Log/LogDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Log/LogDetailsEventList.tsx
@@ -4,16 +4,12 @@ import type { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { LogByIdQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import Link from 'next/link'
 import { FC, useMemo, useState } from 'react'
 import type { Cell } from 'types/table'
 import { countTablePages } from 'utils/table'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   events: NonNullable<NonNullable<LogByIdQuery['consensus_logs'][number]>['block']>['events']

--- a/explorer/src/components/Domain/DomainDetailsCard.tsx
+++ b/explorer/src/components/Domain/DomainDetailsCard.tsx
@@ -2,8 +2,6 @@ import { CopyButton } from 'components/common/CopyButton'
 import { List, StyledListItem } from 'components/common/List'
 import { TOKEN } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import type { DomainByIdQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import useMediaQuery from 'hooks/useMediaQuery'
@@ -12,8 +10,6 @@ import { FC } from 'react'
 import { bigNumberToFormattedString } from 'utils/number'
 import { capitalizeFirstLetter, shortString } from 'utils/string'
 import { AccountIcon } from '../common/AccountIcon'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   domain: DomainByIdQuery['staking_domains_by_pk']

--- a/explorer/src/components/Leaderboard/LeaderboardList.tsx
+++ b/explorer/src/components/Leaderboard/LeaderboardList.tsx
@@ -1,13 +1,12 @@
 'use client'
 
+import { utcToLocalRelativeTime } from '@/utils/time'
 import { DocumentNode, useApolloClient } from '@apollo/client'
 import { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
 import { Spinner } from 'components/common/Spinner'
 import { PAGE_SIZE, TOKEN } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import {
   AccountTransferSenderTotalCountQuery,
   AccountTransferSenderTotalCountQueryVariables,
@@ -30,8 +29,6 @@ import { shortString } from 'utils/string'
 import { countTablePages } from 'utils/table'
 import { AccountIcon } from '../common/AccountIcon'
 import { NotFound } from '../layout/NotFound'
-
-dayjs.extend(relativeTime)
 
 type LeaderboardListProps = {
   title: string
@@ -128,7 +125,7 @@ export const LeaderboardList: FC<LeaderboardListProps> = ({
         enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
           <div key={`last_contribution_at-${row.original.id}`}>
-            {dayjs(row.original.last_contribution_at).fromNow(true) + ' ago'}
+            {utcToLocalRelativeTime(row.original.last_contribution_at)}
           </div>
         ),
       })

--- a/explorer/src/components/Staking/NominationsTable.tsx
+++ b/explorer/src/components/Staking/NominationsTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { utcToLocalRelativeTime } from '@/utils/time'
 import { sendGAEvent } from '@next/third-parties/google'
 import { SortingState, createColumnHelper } from '@tanstack/react-table'
 import { Accordion } from 'components/common/Accordion'
@@ -8,8 +9,6 @@ import { Spinner } from 'components/common/Spinner'
 import { BIGINT_ZERO, TOKEN } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { OperatorPendingAction, OperatorStatus } from 'constants/staking'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import {
   NominationsListQuery,
   NominationsListQueryVariables,
@@ -28,8 +27,6 @@ import { MyPositionSwitch } from '../common/MyPositionSwitch'
 import { ActionsDropdown, ActionsDropdownRow } from './ActionsDropdown'
 import { ActionsModal, OperatorAction, OperatorActionType } from './ActionsModal'
 import { QUERY_NOMINATIONS_LIST } from './query'
-
-dayjs.extend(relativeTime)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const columnHelper = createColumnHelper<any>()
@@ -109,7 +106,7 @@ export const NominationsTable: FC = () => {
       header: 'Storage Fee',
     }),
     columnHelper.accessor('timestamp', {
-      cell: (info) => dayjs(info.getValue()).fromNow(),
+      cell: (info) => utcToLocalRelativeTime(info.getValue()),
       header: 'Time',
     }),
     columnHelper.accessor('created_at', {

--- a/explorer/src/components/Staking/NominationsTable.tsx
+++ b/explorer/src/components/Staking/NominationsTable.tsx
@@ -145,7 +145,7 @@ export const NominationsTable: FC = () => {
       header: 'Unlocked Total Amount',
     }),
     columnHelper.accessor('timestamp', {
-      cell: (info) => dayjs(info.getValue()).fromNow(),
+      cell: (info) => utcToLocalRelativeTime(info.getValue()),
       header: 'Time',
     }),
     columnHelper.accessor('created_at', {

--- a/explorer/src/components/Staking/OperatorDetailsCard.tsx
+++ b/explorer/src/components/Staking/OperatorDetailsCard.tsx
@@ -2,8 +2,6 @@ import { CopyButton } from 'components/common/CopyButton'
 import { List, StyledListItem } from 'components/common/List'
 import { TOKEN } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import type { OperatorByIdQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import useMediaQuery from 'hooks/useMediaQuery'
@@ -13,8 +11,6 @@ import { bigNumberToFormattedString } from 'utils/number'
 import { operatorStatus } from 'utils/operator'
 import { capitalizeFirstLetter, shortString } from 'utils/string'
 import { AccountIcon } from '../common/AccountIcon'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   operator: OperatorByIdQuery['staking_operators_by_pk']

--- a/explorer/src/components/WalletSideKick/LastExtrinsics.tsx
+++ b/explorer/src/components/WalletSideKick/LastExtrinsics.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { utcToLocalRelativeTime } from '@/utils/time'
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { Accordion } from 'components/common/Accordion'
 import { List, StyledListItem } from 'components/common/List'
@@ -11,8 +12,6 @@ import {
   ROUTE_FLAG_VALUE_OPEN_CLOSE,
   Routes,
 } from 'constants/routes'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { ExtrinsicsSummaryQuery, ExtrinsicsSummaryQueryVariables } from 'gql/graphql'
 import useChains from 'hooks/useChains'
 import { useSquidQuery } from 'hooks/useSquidQuery'
@@ -27,8 +26,6 @@ import { QUERY_EXTRINSIC_SUMMARY } from './query'
 interface LastExtrinsicsProps {
   subspaceAccount: string
 }
-
-dayjs.extend(relativeTime)
 
 export const LastExtrinsics: FC<LastExtrinsicsProps> = ({ subspaceAccount }) => {
   const { ref, inView } = useInView()
@@ -105,8 +102,8 @@ export const LastExtrinsics: FC<LastExtrinsicsProps> = ({ subspaceAccount }) => 
                         extrinsic.id,
                       )}
                     >
-                      <Tooltip text={dayjs(extrinsic.timestamp).toString()}>
-                        {dayjs(extrinsic.timestamp).fromNow(true)}
+                      <Tooltip text={extrinsic.timestamp}>
+                        {utcToLocalRelativeTime(extrinsic.timestamp)}
                       </Tooltip>
                     </Link>
                   }

--- a/explorer/src/components/WalletSideKick/index.tsx
+++ b/explorer/src/components/WalletSideKick/index.tsx
@@ -2,6 +2,7 @@
 
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
+import { currentYear } from '@/utils/time'
 import { sendGAEvent } from '@next/third-parties/google'
 import { LogoIcon, WalletIcon } from 'components/icons'
 import { HeaderBackground } from 'components/layout/HeaderBackground'
@@ -11,7 +12,6 @@ import {
   ROUTE_FLAG_VALUE_OPEN_CLOSE,
 } from 'constants/routes'
 import { WalletType } from 'constants/wallet'
-import dayjs from 'dayjs'
 import useChains from 'hooks/useChains'
 import useMediaQuery from 'hooks/useMediaQuery'
 import useWallet from 'hooks/useWallet'
@@ -212,7 +212,7 @@ const Drawer: FC<DrawerProps> = ({ isOpen, onClose }) => {
             <div className='flex'>
               <div className='flex flex-col flex-wrap justify-items-end pb-1 pl-5 pt-10 sm:hidden sm:flex-row'>
                 <p className='text-gray text-center text-sm sm:text-left'>
-                  © {dayjs().year()} Subspace Labs, Inc. All Rights Reserved
+                  © {currentYear()} Subspace Labs, Inc. All Rights Reserved
                 </p>
               </div>
             </div>

--- a/explorer/src/components/common/PageTabs.tsx
+++ b/explorer/src/components/common/PageTabs.tsx
@@ -1,11 +1,5 @@
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { FC, ReactElement } from 'react'
-
-// common
 import { Tabs } from './Tabs'
-
-dayjs.extend(relativeTime)
 
 type Props = {
   children: ReactElement[] | ReactElement

--- a/explorer/src/components/layout/Footer.tsx
+++ b/explorer/src/components/layout/Footer.tsx
@@ -1,11 +1,8 @@
-import dayjs from 'dayjs'
-import Link from 'next/link'
-
-import type { FC } from 'react'
-
-// common
+import { currentYear } from '@/utils/time'
 import { LogoIcon } from 'components/icons'
 import { EXTERNAL_ROUTES } from 'constants/routes'
+import Link from 'next/link'
+import type { FC } from 'react'
 
 const Footer: FC = () => {
   return (
@@ -21,7 +18,7 @@ const Footer: FC = () => {
               </div>
               <div className='container mx-auto hidden flex-col flex-wrap pb-1 pr-5 pt-20 sm:flex sm:flex-row'>
                 <p className='text-center text-xs text-whiteOpaque sm:text-left'>
-                  © {dayjs().year()} Autonomys Labs, Inc. All Rights Reserved
+                  © {currentYear()} Autonomys Labs, Inc. All Rights Reserved
                 </p>
               </div>
             </div>
@@ -155,7 +152,7 @@ const Footer: FC = () => {
         </div>
         <div className='container mx-auto flex flex-col flex-wrap pb-1 pr-5 pt-20 sm:hidden sm:flex-row'>
           <p className='text-center text-sm text-whiteOpaque sm:text-left'>
-            © {dayjs().year()} Subspace Labs, Inc. All Rights Reserved
+            © {currentYear()} Subspace Labs, Inc. All Rights Reserved
           </p>
         </div>
       </div>

--- a/explorer/src/components/layout/MobileHeader.tsx
+++ b/explorer/src/components/layout/MobileHeader.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import { currentYear } from '@/utils/time'
 import { MoonIcon, SunIcon } from '@heroicons/react/20/solid'
 import { LogoIcon } from 'components/icons'
-import dayjs from 'dayjs'
 import useChains from 'hooks/useChains'
 import { useRouter } from 'next/navigation'
 import { useTheme } from 'providers/ThemeProvider'
@@ -107,7 +107,7 @@ const Drawer: FC<Props> = ({ children, menuList, isOpen, setIsOpen }) => {
           <div className='flex'>
             <div className='flex flex-col flex-wrap justify-items-end pb-1 pl-5 pt-10 sm:hidden sm:flex-row'>
               <p className='text-gray text-center text-sm sm:text-left'>
-                © {dayjs().year()} Subspace Labs, Inc. All Rights Reserved
+                © {currentYear()} Subspace Labs, Inc. All Rights Reserved
               </p>
             </div>
           </div>

--- a/explorer/src/utils/time.ts
+++ b/explorer/src/utils/time.ts
@@ -1,3 +1,10 @@
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(relativeTime)
+dayjs.extend(utc)
+
 export const formatSeconds = (seconds: number | bigint): string => {
   if (typeof seconds === 'number' && seconds < 0) {
     throw new Error('Seconds cannot be negative')
@@ -27,3 +34,11 @@ export const formatSeconds = (seconds: number | bigint): string => {
       .trim() || '0s'
   )
 }
+
+export const utcToLocalRelativeTime = (timestamp: string): string =>
+  dayjs.utc(timestamp).local().fromNow(true) + ' ago'
+
+export const utcToLocalTime = (timestamp: string): string =>
+  dayjs.utc(timestamp).local().format('DD MMM YYYY | HH:mm:ss(Z)')
+
+export const currentYear = (): number => dayjs().year()


### PR DESCRIPTION
### **User description**
## Fix timestamp to local time

The timestamp was in UTC time, now converted to local and improve code reusability in the process


___

### **PR Type**
enhancement


___

### **Description**
- Replaced `dayjs` usage with custom utility functions `utcToLocalRelativeTime` and `utcToLocalTime` across multiple components to handle timestamp conversion.
- Removed unnecessary `dayjs` and `relativeTime` imports from various files.
- Introduced `currentYear` utility function to dynamically display the current year in footers and headers.
- Enhanced code reusability and maintainability by centralizing time conversion logic.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>route.tsx</strong><dd><code>Replace dayjs with utcToLocalRelativeTime for timestamps</code>&nbsp; </dd></summary>
<hr>

explorer/src/app/[chain]/consensus/accounts/[accountId]/image/route.tsx

<li>Removed <code>dayjs</code> and <code>relativeTime</code> imports.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-7e53da239cb9a3f12f0eb9accd410fe5a6f9a8265c96bd58317f87877608e2eb">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountExtrinsicList.tsx</strong><dd><code>Use utcToLocalRelativeTime for extrinsic timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-bda77c8265dae0962030dcf3d0533e2bf7965a6829d8ff37f77c4bdf3b7f9d9e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountRewardList.tsx</strong><dd><code>Use utcToLocalRelativeTime for reward timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountRewardList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-f0dd9aa976a027f4dafc25bbf6042592aa1b4612ee8f3e6c7e567e6a537a57b1">+6/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountTransfersList.tsx</strong><dd><code>Use utcToLocalRelativeTime for transfer timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountTransfersList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-afd94db3a36e317fce480fbaece463ae43c37fbb01aa8150fc386a52774cd5de">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlockDetailsCard.tsx</strong><dd><code>Use utcToLocal functions for block timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Block/BlockDetailsCard.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code> and <code>utcToLocalTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-10a6713651e715f784b78f2dfffd25d49372f4c40441e523bc86463560fe3b8b">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlockDetailsExtrinsicList.tsx</strong><dd><code>Use utcToLocalRelativeTime for extrinsic timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-cf160cd96f9bb39cf22de950ba70d9a4299942cb702bdd52860cb47d7fc3fe3c">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlockList.tsx</strong><dd><code>Use utcToLocalRelativeTime for block list timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Block/BlockList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-1fd78c7164fd845bbcab711583acf55daec431126e9bd31eb65784de24fb7e83">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>EventDetailsCard.tsx</strong><dd><code>Use utcToLocal functions for event timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Event/EventDetailsCard.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code> and <code>utcToLocalTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-547ac5cc90161345a862a8b774c7597cee2befe45e412ff54eabe135787d2d3e">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>EventList.tsx</strong><dd><code>Use utcToLocalRelativeTime for event list timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Event/EventList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-f9668fdac9338cc529d6eae04188739a10dc176154e3eebc20ed101e4bb3e325">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ExtrinsicDetailsCard.tsx</strong><dd><code>Use utcToLocal functions for extrinsic timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsCard.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code> and <code>utcToLocalTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-ec1eafaeaf2fe5c2c51d5f511505725ea4b51d693894022ec765b291a2fa45d6">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ExtrinsicList.tsx</strong><dd><code>Use utcToLocalRelativeTime for extrinsic list timestamps</code>&nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-6d5f265eac35112e020c6d81f064f33927fe8b039164a62e5fc934912a508922">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HomeBlockList.tsx</strong><dd><code>Use utcToLocalRelativeTime for home block list timestamps</code></dd></summary>
<hr>

explorer/src/components/Consensus/Home/HomeBlockList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-89e12a7a0280749632b5d4a4106cc40add329a62463652a266a91112a36de7c6">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HomeExtrinsicList.tsx</strong><dd><code>Use utcToLocalRelativeTime for home extrinsic list timestamps</code></dd></summary>
<hr>

explorer/src/components/Consensus/Home/HomeExtrinsicList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-306a62336d4da6d9afd520f2d9aeb12693a8b9c2ecbdae218c231e0d2a21635f">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LeaderboardList.tsx</strong><dd><code>Use utcToLocalRelativeTime for leaderboard timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Leaderboard/LeaderboardList.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-59ab3107908d3924d60228fdba039fc2855ada4765023ba57226117b602326e9">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NominationsTable.tsx</strong><dd><code>Use utcToLocalRelativeTime for nomination timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Staking/NominationsTable.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-ba8eca7d4b307e4d61732f10fb6d2f1c2e8c8fe7d4409a78c6724bddf75de2d2">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LastExtrinsics.tsx</strong><dd><code>Use utcToLocalRelativeTime for last extrinsics timestamps</code></dd></summary>
<hr>

explorer/src/components/WalletSideKick/LastExtrinsics.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>utcToLocalRelativeTime</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-1ea921417daf04e3f27971fff139d201a2bea1a271add0a81067a12aad9f876a">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Use currentYear for footer year display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/WalletSideKick/index.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>currentYear</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-04afecfb82054a461cae9c2d39d5f4b4348149a77d548bb44afe946a1acdffca">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Footer.tsx</strong><dd><code>Use currentYear for footer year display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/layout/Footer.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>currentYear</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-83bb5ee4cddbe8f569a7dc58d64f4197abdb1636fc7d0729b1cd373c88bd62e4">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>MobileHeader.tsx</strong><dd><code>Use currentYear for mobile header year display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/layout/MobileHeader.tsx

<li>Removed <code>dayjs</code> import.<br> <li> Replaced <code>dayjs</code> usage with <code>currentYear</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-f650fb9297a8cf2ae06683db422baa2402e468b412d9cfdfe2b7af2de5e35cf3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>time.ts</strong><dd><code>Add utility functions for time conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/utils/time.ts

<li>Added <code>utcToLocalRelativeTime</code> and <code>utcToLocalTime</code> functions.<br> <li> Added <code>currentYear</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-584167bf3049d0fbc1289236fcb427073c941621053583441f11f48a21cd2cbd">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>route.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/app/[chain]/image/route.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-43860c8c9850589692534a1b304961ef75a6ce69f6b5113aabee5f8f816b8f5c">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountGraphs.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountGraphs.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-ef307efb7dfd878c4875c6db2b41e98399fd1e8d38225f894655960452630a86">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountLatestRewards.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountLatestRewards.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-3502754c5789d16d84175b44b0adae942d69c81d7729e3d432577b7f746efd6e">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountPreviousRewards.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountPreviousRewards.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-8e3727ff57139c5207fda22d91439d50e5316030f92ce46cf616395d4c6a25e2">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountRewardsHistory.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountRewardsHistory.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-25c5984711a35378aa3266cf63763c090a8998a36520079b7b3d67fab16ad37a">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlockDetailsEventList.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-e1426e45a71a8875edc2ac7f418ff13f8f145db23ddf66017ab20fef2c4c20dd">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlockDetailsLogList.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Block/BlockDetailsLogList.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-5ee80d5f4e992f594736282d0b05c20b4f015994dbb8c16d523a37991d95d6d8">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlockDetailsTabs.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Block/BlockDetailsTabs.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-0cc691ee64805862b9849e0d73445d2bf66cf03a376643d2341dc90d5d4ed112">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ExtrinsicDetailsEventList.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsEventList.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-ed7f182457edac2d2c47cfdf6253fddb71e074df5096e298b837c8f4b7d5c563">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LogDetailsCard.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Log/LogDetailsCard.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-4e0a8b510526a8148d1dc7614dc3530e5e2735d5d267a1add21d3acf35460a8d">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LogDetailsEventList.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Log/LogDetailsEventList.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-aa1004dace52d771549c640aa38c66a73be577cdcc05fe996d814f9963ff29fd">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DomainDetailsCard.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Domain/DomainDetailsCard.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-30616992aad97a2a95af2c42e407364096d3ffe4caf1e90eae95fe380cbda960">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>OperatorDetailsCard.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Staking/OperatorDetailsCard.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-1e76bf72eed93f696ffdb5a39b2e1649eba7c0a1d8e3e6a4d9adfb9234a662d7">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PageTabs.tsx</strong><dd><code>Remove unused dayjs imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/common/PageTabs.tsx

- Removed `dayjs` and `relativeTime` imports.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/913/files#diff-f8de372a0aefbff52c02ee09fdc7d252f8ee7924a20b585e36e25bf52bd87a4d">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information