### PR TITLE
Add support for su address prefix in testnet rewards

### DIFF
--- a/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
+++ b/explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { SUBSPACE_ACC_PREFIX_TESTNET } from '@/constants/general'
+import { formatAddress } from '@/utils/formatAddress'
 import { sendGAEvent } from '@next/third-parties/google'
 import {
   AriesStressTestIcon,
@@ -112,6 +114,14 @@ export const TestnetRewardsTable: FC = () => {
   const [allRewards, setAllRewards] = useState<AllRewards[]>([])
   const [rewards, setRewards] = useState<Rewards>(DEFAULT_REWARDS)
   const [totalRewards, setTotalRewards] = useState<Rewards>(DEFAULT_REWARDS)
+
+  const stFormattedAndMergedAddresses = useMemo(() => {
+    const addresses = mySubspaceWallets.map((wallet) =>
+      formatAddress(wallet, SUBSPACE_ACC_PREFIX_TESTNET),
+    )
+    if (subspaceAccount) addresses.push(formatAddress(subspaceAccount, SUBSPACE_ACC_PREFIX_TESTNET))
+    return addresses
+  }, [mySubspaceWallets, subspaceAccount])
 
   const campaigns: Record<string, Campaign> = useMemo(
     () => ({
@@ -291,8 +301,8 @@ export const TestnetRewardsTable: FC = () => {
 
   const handleAggregated = useCallback(async () => {
     if (!isLoaded) return
-    const userRewards = allRewards.filter(
-      (reward) => mySubspaceWallets.includes(reward.address) || subspaceAccount === reward.address,
+    const userRewards = allRewards.filter((reward) =>
+      stFormattedAndMergedAddresses.includes(reward.address),
     )
 
     const mergedRewards: Rewards = userRewards.reduce(
@@ -323,7 +333,7 @@ export const TestnetRewardsTable: FC = () => {
     )
     setRewards(mergedRewards)
     setIsAggregated(true)
-  }, [allRewards, campaigns, isLoaded, mySubspaceWallets, subspaceAccount])
+  }, [allRewards, campaigns, isLoaded, stFormattedAndMergedAddresses])
 
   const userTestnetRewardsByPhase = useCallback(
     (phase: string) => {

--- a/explorer/src/constants/general.ts
+++ b/explorer/src/constants/general.ts
@@ -40,6 +40,7 @@ export const searchTypes: SearchType[] = [
 ]
 
 export const SUBSPACE_ACC_PREFIX = 6094
+export const SUBSPACE_ACC_PREFIX_TESTNET = 2254
 
 export const BIGINT_ZERO = BigInt(0)
 

--- a/explorer/src/utils/formatAddress.ts
+++ b/explorer/src/utils/formatAddress.ts
@@ -1,13 +1,16 @@
 import { decode, isAddress, Keyring, u8aToHex } from '@autonomys/auto-utils'
 import { SUBSPACE_ACC_PREFIX } from 'constants/general'
 
-export const formatAddress = (accountId?: string): string | undefined => {
+export const formatAddress = (
+  accountId?: string,
+  ss58Format = SUBSPACE_ACC_PREFIX,
+): string | undefined => {
   if (!accountId || !isAddress(accountId)) return undefined
 
   const keyring = new Keyring({ type: 'sr25519', ss58Format: 42 })
   let address
   try {
-    address = keyring.encodeAddress(accountId, SUBSPACE_ACC_PREFIX)
+    address = keyring.encodeAddress(accountId, ss58Format)
   } catch (error) {
     return undefined
   }


### PR DESCRIPTION
### **User description**
## Add support for su address prefix in testnet rewards

Resolve both testnet and mainnet addresses to the st format to verify testnet allocation


___

### **PR Type**
enhancement


___

### **Description**
- Added support for formatting addresses with a testnet prefix in the `TestnetRewardsTable` component.
- Introduced a new constant `SUBSPACE_ACC_PREFIX_TESTNET` for testnet address handling.
- Enhanced the `formatAddress` utility function to accept a custom SS58 format, allowing flexible address encoding.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestnetRewardsTable.tsx</strong><dd><code>Add support for testnet address formatting in rewards table</code></dd></summary>
<hr>

explorer/src/components/TestnetRewards/TestnetRewardsTable.tsx

<li>Added support for formatting addresses with a testnet prefix.<br> <li> Introduced <code>stFormattedAndMergedAddresses</code> to handle address formatting.<br> <li> Updated logic to filter rewards using formatted addresses.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/923/files#diff-35e3074a14443524d99d3004b4fa803bb33ed43a0649f85383a66ac28bdc1e76">+13/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>formatAddress.ts</strong><dd><code>Enhance address formatting utility for custom prefixes</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/utils/formatAddress.ts

<li>Modified <code>formatAddress</code> function to accept a custom SS58 format.<br> <li> Updated address encoding logic to use the provided SS58 format.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/923/files#diff-ffccfbbcb813309b5f6c40cd232c7300b9f986a6be2f8a3d83dbed4d756f1424">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>general.ts</strong><dd><code>Add constant for testnet address prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/constants/general.ts

- Introduced a new constant `SUBSPACE_ACC_PREFIX_TESTNET`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/923/files#diff-3003cef0777f86baed95989b26937ac637617cce3073d73e20d874869d888fb3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information