### PR TITLE
Expose hasura endpoint and subql health endpoint

### DIFF
--- a/indexers/Caddyfile
+++ b/indexers/Caddyfile
@@ -80,3 +80,147 @@
         level INFO
     }
 }
+
+# Hasura endpoint
+:8080 {
+    # Match WebSocket requests
+    @websockets {
+        header Connection *Upgrade*
+        header Upgrade websocket
+    }
+
+    # Reverse proxy for WebSocket traffic explicitly over HTTP/1.1
+    reverse_proxy @websockets node:8080 {
+        transport http {
+            versions h1  # Force HTTP/1.1 only for WebSocket traffic
+        }
+        # Headers for WebSocket support
+        header_up Connection "Upgrade"
+        header_up Upgrade "websocket"
+    }
+
+    # Reverse proxy for HTTP traffic to node at port 9944
+    reverse_proxy node:8080 {
+        transport http {
+            # Buffer sizes
+            read_buffer 64KB
+            write_buffer 64KB
+
+            # Timeouts
+            dial_timeout 10s
+            dial_fallback_delay 300ms
+            response_header_timeout 30s
+            expect_continue_timeout 1s
+
+            # Keep-alive settings
+            keepalive 90s
+            keepalive_interval 30s
+            keepalive_idle_conns 2000
+            keepalive_idle_conns_per_host 500
+
+            # Compression and HTTP versions
+            compression off
+            versions h2c h1
+
+            # Connection limits
+            max_conns_per_host 150000
+        }
+    }
+
+    # CORS Headers
+    header {
+        Access-Control-Allow-Origin "*"
+        Access-Control-Allow-Methods "GET, POST, OPTIONS"
+        Access-Control-Allow-Headers "Content-Type"
+        # Add security headers
+        Strict-Transport-Security "max-age=31536000;"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        defer  # Process headers after proxied response
+    }
+
+    # Logging configuration
+    log {
+        output file /data/access.log {
+            roll_size 10MB
+            roll_keep 10
+        }
+        format console
+        level INFO
+    }
+}
+
+# Subql Health endpoint
+:3000 {
+    # Match WebSocket requests
+    @websockets {
+        header Connection *Upgrade*
+        header Upgrade websocket
+    }
+
+    # Reverse proxy for WebSocket traffic explicitly over HTTP/1.1
+    reverse_proxy @websockets node:3000 {
+        transport http {
+            versions h1  # Force HTTP/1.1 only for WebSocket traffic
+        }
+        # Headers for WebSocket support
+        header_up Connection "Upgrade"
+        header_up Upgrade "websocket"
+    }
+
+    # Reverse proxy for HTTP traffic to node at port 9944
+    reverse_proxy node:3000 {
+        transport http {
+            # Buffer sizes
+            read_buffer 64KB
+            write_buffer 64KB
+
+            # Timeouts
+            dial_timeout 10s
+            dial_fallback_delay 300ms
+            response_header_timeout 30s
+            expect_continue_timeout 1s
+
+            # Keep-alive settings
+            keepalive 90s
+            keepalive_interval 30s
+            keepalive_idle_conns 2000
+            keepalive_idle_conns_per_host 500
+
+            # Compression and HTTP versions
+            compression off
+            versions h2c h1
+
+            # Connection limits
+            max_conns_per_host 150000
+        }
+
+        # Health checks
+        health_uri /health
+        health_interval 30s
+        health_timeout 5s
+        health_status 200
+    }
+
+    # CORS Headers
+    header {
+        Access-Control-Allow-Origin "*"
+        Access-Control-Allow-Methods "GET, POST, OPTIONS"
+        Access-Control-Allow-Headers "Content-Type"
+        # Add security headers
+        Strict-Transport-Security "max-age=31536000;"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        defer  # Process headers after proxied response
+    }
+
+    # Logging configuration
+    log {
+        output file /data/access.log {
+            roll_size 10MB
+            roll_keep 10
+        }
+        format console
+        level INFO
+    }
+}


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added configuration for a Hasura endpoint on port 8080, including reverse proxy settings for WebSocket and HTTP traffic.
- Introduced a Subql health endpoint on port 3000 with health check configurations.
- Configured CORS headers and security headers for both endpoints.
- Enhanced logging configuration for both endpoints.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Caddyfile</strong><dd><code>Add Hasura and Subql endpoint configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/Caddyfile

<li>Added Hasura endpoint configuration on port 8080.<br> <li> Added Subql health endpoint configuration on port 3000.<br> <li> Configured reverse proxy for WebSocket and HTTP traffic.<br> <li> Implemented CORS and security headers.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/925/files#diff-8c93321a56d0377d04ecc3800259cf3f6d0f3dc73681ea63f4b91ac0b46f5ed2">+144/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information