### PR TITLE
auth and fix hasura proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,12 @@ services:
         hard: 65536 # Hard limit for open files
     image: caddy:latest
     ports:
-      - "80:80" # Map port 80 on the host to port 80 in Caddy
-      - "443:443" # Map port 443 for HTTPS
+    - "80:9944"    # Map external 80 to Caddy's 9944 for Node/RPC
+    - "443:9945"   # Map external 443 to Caddy's 9945 for HTTPS
+    - "8081:8080"  # Map external 8081 to Caddy's 8080 for Hasura
+    - "3011:3001"  # Map external 3011 to Caddy's 3001 for Consensus
+    - "3012:3002"  # Map external 3012 to Caddy's 3002 for Leaderboard
+    - "3013:3003"  # Map external 3013 to Caddy's 3003 for Staking
     volumes:
       - ./indexers/Caddyfile:/etc/caddy/Caddyfile # Mount the Caddyfile
       - caddy_data:/data # Volume for Let's Encrypt certificates

--- a/indexers/Caddyfile
+++ b/indexers/Caddyfile
@@ -91,6 +91,7 @@
 
 # Hasura endpoint
 :8080 {
+    import auth
     # Match WebSocket requests
     @websockets {
         header Connection *Upgrade*
@@ -108,7 +109,7 @@
     }
 
     # Reverse proxy for HTTP traffic to hasura at port 8080
-    reverse_proxy node:8080 {
+    reverse_proxy hasura:8080 {
         transport http {
             # Buffer sizes
             read_buffer 64KB
@@ -160,6 +161,7 @@
 
 # Subql Consensus Health endpoint
 :3001 {
+    import auth
     # Match WebSocket requests
     @websockets {
         header Connection *Upgrade*
@@ -235,6 +237,7 @@
 
 # Subql Leaderboard Health endpoint
 :3002 {
+    import auth
     # Match WebSocket requests
     @websockets {
         header Connection *Upgrade*
@@ -310,6 +313,7 @@
 
 # Subql Staking Health endpoint
 :3003 {
+    import auth
     # Match WebSocket requests
     @websockets {
         header Connection *Upgrade*


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Improves https://github.com/autonomys/astral/pull/927
- Added `import auth` to several endpoints to ensure authentication is applied.
- Corrected the reverse proxy configuration to direct traffic to `hasura:8080` instead of `node:8080`.
- open other ports through caddy.
- Improved logging setup across multiple endpoints to maintain consistency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Caddyfile</strong><dd><code>Add authentication and fix Hasura proxy configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/Caddyfile

<li>Added <code>import auth</code> to multiple endpoints for authentication.<br> <li> Changed reverse proxy target from <code>node:8080</code> to <code>hasura:8080</code>.<br> <li> Enhanced logging configuration for various endpoints.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/928/files#diff-8c93321a56d0377d04ecc3800259cf3f6d0f3dc73681ea63f4b91ac0b46f5ed2">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information