### PR TITLE
Remove platform tag for node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
   # Subspace Node
   node:
     image: ghcr.io/autonomys/node:${NODE_DOCKER_TAG}
-    platform: linux/amd64
     volumes:
       - node-data:/var/subspace:rw
     ports:


### PR DESCRIPTION
### **User description**
## Remove platform tag for node


___

### **PR Type**
configuration changes


___

### **Description**
- Removed the `platform` tag from the `node` service in the `docker-compose.yml` file to allow for more flexible deployments.
- This change may help in running the service on different architectures without being restricted to `linux/amd64`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Remove platform specification from node service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Removed the <code>platform</code> specification for the <code>node</code> service.<br> <li> The <code>platform</code> was set to <code>linux/amd64</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/937/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information