### PR TITLE
fix ports for indexer services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,8 +190,8 @@ services:
   consensus_subquery_node:
     profiles: [indexers]
     image: subquerynetwork/subql-node-substrate:latest
-    expose:
-      - "3001"
+    ports:
+      - "3001:3000"
     depends_on:
       "postgres":
         condition: service_healthy
@@ -227,8 +227,8 @@ services:
   leaderboard_subquery_node:
     profiles: [indexers]
     image: subquerynetwork/subql-node-substrate:latest
-    expose:
-      - "3002"
+    ports:
+      - "3002:3000"
     depends_on:
       "postgres":
         condition: service_healthy
@@ -263,8 +263,8 @@ services:
   staking_subquery_node:
     profiles: [indexers]
     image: subquerynetwork/subql-node-substrate:latest
-    expose:
-      - "3003"
+    ports:
+      - "3003:3000"
     depends_on:
       "postgres":
         condition: service_healthy


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the `docker-compose.yml` file to change the port configuration for indexer services.
- Replaced `expose` with `ports` to map external ports 3001, 3002, and 3003 to internal port 3000 for the consensus, leaderboard, and staking subquery nodes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Update port configuration for indexer services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Changed <code>expose</code> to <code>ports</code> for indexer services.<br> <li> Mapped external ports 3001, 3002, and 3003 to internal port 3000.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/940/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information