### PR TITLE
Change subscan url

### DIFF
--- a/.vscode/astral.code-workspace
+++ b/.vscode/astral.code-workspace
@@ -56,6 +56,7 @@
       "gemini",
       "graphiql",
       "leaderboard",
+      "polkadot",
       "siwe",
       "subscan",
       "subspace",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
     "gemini",
     "graphiql",
     "leaderboard",
+    "polkadot",
     "siwe",
     "subscan",
     "subspace",

--- a/explorer/src/components/common/IndexingError.tsx
+++ b/explorer/src/components/common/IndexingError.tsx
@@ -1,9 +1,12 @@
+import { NetworkId } from '@autonomys/auto-utils'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { EXTERNAL_ROUTES } from 'constants/routes'
+import useChain from 'hooks/useChains'
 import { FC, useCallback, useState } from 'react'
 
 export const IndexingError: FC = () => {
   const [isWarningVisible, setIsWarningVisible] = useState(true)
+  const { network } = useChain()
 
   const handleHideWarning = useCallback(() => {
     setIsWarningVisible(false)
@@ -17,17 +20,21 @@ export const IndexingError: FC = () => {
         <p>
           We are currently experiencing issues with our indexing service. Please bear with us as we
           work to resolve this issue. You can check{' '}
+          {network === NetworkId.MAINNET && (
+            <>
+              <a
+                href={EXTERNAL_ROUTES.subscan}
+                target='_blank'
+                className='text-md text-whiteOpaque hover:text-primaryAccent'
+                rel='noreferrer'
+              >
+                Subscan
+              </a>{' '}
+              or{' '}
+            </>
+          )}
           <a
-            href={EXTERNAL_ROUTES.subscan}
-            target='_blank'
-            className='text-md text-whiteOpaque hover:text-primaryAccent'
-            rel='noreferrer'
-          >
-            Subscan
-          </a>{' '}
-          or{' '}
-          <a
-            href={EXTERNAL_ROUTES.polkadot}
+            href={EXTERNAL_ROUTES.polkadot(network)}
             target='_blank'
             className='text-md text-whiteOpaque hover:text-primaryAccent'
             rel='noreferrer'

--- a/explorer/src/components/common/OutOfSyncBanner.tsx
+++ b/explorer/src/components/common/OutOfSyncBanner.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client'
-import { activate } from '@autonomys/auto-utils'
+import { activate, NetworkId } from '@autonomys/auto-utils'
 import { EXTERNAL_ROUTES } from 'constants/routes'
 import { LastBlockQuery } from 'gql/graphql'
 import useChains from 'hooks/useChains'
@@ -10,6 +10,7 @@ import { LAST_BLOCK } from './query'
 const NORMAL_BLOCKS_DIVERGENCE = 120
 
 const OutOfSyncBanner: FC = () => {
+  const { network } = useChains()
   return (
     <div className="container mx-auto mb-4 flex grow justify-center px-5 font-['Montserrat'] md:px-[25px] 2xl:px-0">
       <div className='sticky top-0 z-50 w-full'>
@@ -24,12 +25,14 @@ const OutOfSyncBanner: FC = () => {
               or use Polkadot.js Apps to interact with the chain.
             </div>
             <div>
-              <Link href={EXTERNAL_ROUTES.subscan} target='_blank'>
-                <button className='self-start rounded-[20px] bg-white px-[33px] py-[13px] text-sm font-medium text-gray-800 hover:bg-gray-200 dark:bg-[#1E254E] dark:text-white'>
-                  Visit Subscan
-                </button>
-              </Link>
-              <Link className='ml-4' href={EXTERNAL_ROUTES.polkadot} target='_blank'>
+              {network === NetworkId.MAINNET && (
+                <Link href={EXTERNAL_ROUTES.subscan} target='_blank'>
+                  <button className='self-start rounded-[20px] bg-white px-[33px] py-[13px] text-sm font-medium text-gray-800 hover:bg-gray-200 dark:bg-[#1E254E] dark:text-white'>
+                    Visit Subscan
+                  </button>
+                </Link>
+              )}
+              <Link className='ml-4' href={EXTERNAL_ROUTES.polkadot(network)} target='_blank'>
                 <button className='self-start rounded-[20px] bg-white px-[33px] py-[13px] text-sm font-medium text-gray-800 hover:bg-gray-200 dark:bg-[#1E254E] dark:text-white'>
                   Visit Polkadot.js Apps
                 </button>

--- a/explorer/src/constants/routes.ts
+++ b/explorer/src/constants/routes.ts
@@ -78,7 +78,7 @@ export const EXTERNAL_ROUTES = {
   novaExplorer: 'https://nova.subspace.network/',
   polkadot:
     'https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.gemini-3h.subspace.network%2Fws#/explorer',
-  subscan: 'https://subspace.subscan.io/',
+  subscan: 'https://autonomys.subscan.io/',
   spaceAcres: 'https://api.github.com/repos/subspace/space-acres/releases/latest',
 }
 

--- a/explorer/src/constants/routes.ts
+++ b/explorer/src/constants/routes.ts
@@ -76,8 +76,8 @@ export const EXTERNAL_ROUTES = {
     subSocial: 'https://app.subsocial.network/@NetworkSubspace',
   },
   novaExplorer: 'https://nova.subspace.network/',
-  polkadot:
-    'https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.gemini-3h.subspace.network%2Fws#/explorer',
+  polkadot: (network: NetworkId): string =>
+    `https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.${network}.subspace.network%2Fws#/explorer`,
   subscan: 'https://autonomys.subscan.io/',
   spaceAcres: 'https://api.github.com/repos/subspace/space-acres/releases/latest',
 }


### PR DESCRIPTION
### **User description**
## Change subscan url

Subscan Autonomys mainnet explorer is up at https://autonomys.subscan.io/

The old subspace URL is not valid anymore

I also improved the logic of out of sync component to support mainnet and testnet


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the Subscan URL to point to the new Autonomys mainnet explorer.
- Enhanced the `OutOfSyncBanner` component to display network-specific links for Subscan and Polkadot.js Apps.
- Modified the external routes configuration to support network-specific URLs.
- Added "polkadot" to the list of known words in the spell checker configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OutOfSyncBanner.tsx</strong><dd><code>Enhance OutOfSyncBanner with network-specific links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/common/OutOfSyncBanner.tsx

<li>Added network-specific logic for displaying Subscan link.<br> <li> Updated Polkadot.js Apps link to be network-specific.<br> <li> Introduced <code>network</code> variable from <code>useChains</code> hook.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/952/files#diff-4babc9c3a2f6222cf07962354c5e6fcc136efad5de58d0096229ab9b1c74e13d">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.ts</strong><dd><code>Update external routes with new Subscan URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/constants/routes.ts

<li>Updated Subscan URL to new Autonomys mainnet explorer.<br> <li> Made Polkadot.js Apps URL network-specific.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/952/files#diff-1db40c1c0135e9c55c149a79c123aafb3fc2408f35965369fe6ff07598b37d91">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>astral.code-workspace</strong><dd><code>Add Polkadot to spell checker known words</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/astral.code-workspace

- Added "polkadot" to known words in spell checker.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/952/files#diff-858fca08e65dd90bdcb3e01501b1e5189457eaf30a9f62d5adb884ba115ac6f8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.json</strong><dd><code>Add Polkadot to spell checker known words</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/settings.json

- Added "polkadot" to known words in spell checker.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/952/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information