### PR TITLE
Add account balance history

### DIFF
--- a/explorer/gql/graphql.ts
+++ b/explorer/gql/graphql.ts
@@ -94,6 +94,47 @@ export type Consensus_Account_Histories = {
   uuid: Scalars['uuid']['output'];
 };
 
+/** aggregated selection of "consensus.account_histories" */
+export type Consensus_Account_Histories_Aggregate = {
+  __typename?: 'consensus_account_histories_aggregate';
+  aggregate?: Maybe<Consensus_Account_Histories_Aggregate_Fields>;
+  nodes: Array<Consensus_Account_Histories>;
+};
+
+/** aggregate fields of "consensus.account_histories" */
+export type Consensus_Account_Histories_Aggregate_Fields = {
+  __typename?: 'consensus_account_histories_aggregate_fields';
+  avg?: Maybe<Consensus_Account_Histories_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Consensus_Account_Histories_Max_Fields>;
+  min?: Maybe<Consensus_Account_Histories_Min_Fields>;
+  stddev?: Maybe<Consensus_Account_Histories_Stddev_Fields>;
+  stddev_pop?: Maybe<Consensus_Account_Histories_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Consensus_Account_Histories_Stddev_Samp_Fields>;
+  sum?: Maybe<Consensus_Account_Histories_Sum_Fields>;
+  var_pop?: Maybe<Consensus_Account_Histories_Var_Pop_Fields>;
+  var_samp?: Maybe<Consensus_Account_Histories_Var_Samp_Fields>;
+  variance?: Maybe<Consensus_Account_Histories_Variance_Fields>;
+};
+
+
+/** aggregate fields of "consensus.account_histories" */
+export type Consensus_Account_Histories_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Consensus_Account_Histories_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Consensus_Account_Histories_Avg_Fields = {
+  __typename?: 'consensus_account_histories_avg_fields';
+  created_at?: Maybe<Scalars['Float']['output']>;
+  free?: Maybe<Scalars['Float']['output']>;
+  nonce?: Maybe<Scalars['Float']['output']>;
+  reserved?: Maybe<Scalars['Float']['output']>;
+  total?: Maybe<Scalars['Float']['output']>;
+  updated_at?: Maybe<Scalars['Float']['output']>;
+};
+
 /** Boolean expression to filter rows from the table "consensus.account_histories". All fields are combined with a logical 'AND'. */
 export type Consensus_Account_Histories_Bool_Exp = {
   _and?: InputMaybe<Array<Consensus_Account_Histories_Bool_Exp>>;
@@ -109,6 +150,32 @@ export type Consensus_Account_Histories_Bool_Exp = {
   total?: InputMaybe<Numeric_Comparison_Exp>;
   updated_at?: InputMaybe<Numeric_Comparison_Exp>;
   uuid?: InputMaybe<Uuid_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Consensus_Account_Histories_Max_Fields = {
+  __typename?: 'consensus_account_histories_max_fields';
+  created_at?: Maybe<Scalars['numeric']['output']>;
+  free?: Maybe<Scalars['numeric']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
+  nonce?: Maybe<Scalars['numeric']['output']>;
+  reserved?: Maybe<Scalars['numeric']['output']>;
+  total?: Maybe<Scalars['numeric']['output']>;
+  updated_at?: Maybe<Scalars['numeric']['output']>;
+  uuid?: Maybe<Scalars['uuid']['output']>;
+};
+
+/** aggregate min on columns */
+export type Consensus_Account_Histories_Min_Fields = {
+  __typename?: 'consensus_account_histories_min_fields';
+  created_at?: Maybe<Scalars['numeric']['output']>;
+  free?: Maybe<Scalars['numeric']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
+  nonce?: Maybe<Scalars['numeric']['output']>;
+  reserved?: Maybe<Scalars['numeric']['output']>;
+  total?: Maybe<Scalars['numeric']['output']>;
+  updated_at?: Maybe<Scalars['numeric']['output']>;
+  uuid?: Maybe<Scalars['uuid']['output']>;
 };
 
 /** Ordering options when selecting data from "consensus.account_histories". */
@@ -147,6 +214,39 @@ export enum Consensus_Account_Histories_Select_Column {
   Uuid = 'uuid'
 }
 
+/** aggregate stddev on columns */
+export type Consensus_Account_Histories_Stddev_Fields = {
+  __typename?: 'consensus_account_histories_stddev_fields';
+  created_at?: Maybe<Scalars['Float']['output']>;
+  free?: Maybe<Scalars['Float']['output']>;
+  nonce?: Maybe<Scalars['Float']['output']>;
+  reserved?: Maybe<Scalars['Float']['output']>;
+  total?: Maybe<Scalars['Float']['output']>;
+  updated_at?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Consensus_Account_Histories_Stddev_Pop_Fields = {
+  __typename?: 'consensus_account_histories_stddev_pop_fields';
+  created_at?: Maybe<Scalars['Float']['output']>;
+  free?: Maybe<Scalars['Float']['output']>;
+  nonce?: Maybe<Scalars['Float']['output']>;
+  reserved?: Maybe<Scalars['Float']['output']>;
+  total?: Maybe<Scalars['Float']['output']>;
+  updated_at?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Consensus_Account_Histories_Stddev_Samp_Fields = {
+  __typename?: 'consensus_account_histories_stddev_samp_fields';
+  created_at?: Maybe<Scalars['Float']['output']>;
+  free?: Maybe<Scalars['Float']['output']>;
+  nonce?: Maybe<Scalars['Float']['output']>;
+  reserved?: Maybe<Scalars['Float']['output']>;
+  total?: Maybe<Scalars['Float']['output']>;
+  updated_at?: Maybe<Scalars['Float']['output']>;
+};
+
 /** Streaming cursor of the table "consensus_account_histories" */
 export type Consensus_Account_Histories_Stream_Cursor_Input = {
   /** Stream column input with initial value */
@@ -166,6 +266,50 @@ export type Consensus_Account_Histories_Stream_Cursor_Value_Input = {
   total?: InputMaybe<Scalars['numeric']['input']>;
   updated_at?: InputMaybe<Scalars['numeric']['input']>;
   uuid?: InputMaybe<Scalars['uuid']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Consensus_Account_Histories_Sum_Fields = {
+  __typename?: 'consensus_account_histories_sum_fields';
+  created_at?: Maybe<Scalars['numeric']['output']>;
+  free?: Maybe<Scalars['numeric']['output']>;
+  nonce?: Maybe<Scalars['numeric']['output']>;
+  reserved?: Maybe<Scalars['numeric']['output']>;
+  total?: Maybe<Scalars['numeric']['output']>;
+  updated_at?: Maybe<Scalars['numeric']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Consensus_Account_Histories_Var_Pop_Fields = {
+  __typename?: 'consensus_account_histories_var_pop_fields';
+  created_at?: Maybe<Scalars['Float']['output']>;
+  free?: Maybe<Scalars['Float']['output']>;
+  nonce?: Maybe<Scalars['Float']['output']>;
+  reserved?: Maybe<Scalars['Float']['output']>;
+  total?: Maybe<Scalars['Float']['output']>;
+  updated_at?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Consensus_Account_Histories_Var_Samp_Fields = {
+  __typename?: 'consensus_account_histories_var_samp_fields';
+  created_at?: Maybe<Scalars['Float']['output']>;
+  free?: Maybe<Scalars['Float']['output']>;
+  nonce?: Maybe<Scalars['Float']['output']>;
+  reserved?: Maybe<Scalars['Float']['output']>;
+  total?: Maybe<Scalars['Float']['output']>;
+  updated_at?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Consensus_Account_Histories_Variance_Fields = {
+  __typename?: 'consensus_account_histories_variance_fields';
+  created_at?: Maybe<Scalars['Float']['output']>;
+  free?: Maybe<Scalars['Float']['output']>;
+  nonce?: Maybe<Scalars['Float']['output']>;
+  reserved?: Maybe<Scalars['Float']['output']>;
+  total?: Maybe<Scalars['Float']['output']>;
+  updated_at?: Maybe<Scalars['Float']['output']>;
 };
 
 /** columns and relationships of "consensus.account_profiles" */
@@ -8345,6 +8489,8 @@ export type Query_Root = {
   __typename?: 'query_root';
   /** fetch data from the table: "consensus.account_histories" */
   consensus_account_histories: Array<Consensus_Account_Histories>;
+  /** fetch aggregated fields from the table: "consensus.account_histories" */
+  consensus_account_histories_aggregate: Consensus_Account_Histories_Aggregate;
   /** fetch data from the table: "consensus.account_histories" using primary key columns */
   consensus_account_histories_by_pk?: Maybe<Consensus_Account_Histories>;
   /** fetch data from the table: "consensus.account_profiles" */
@@ -8617,6 +8763,15 @@ export type Query_Root = {
 
 
 export type Query_RootConsensus_Account_HistoriesArgs = {
+  distinct_on?: InputMaybe<Array<Consensus_Account_Histories_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Account_Histories_Order_By>>;
+  where?: InputMaybe<Consensus_Account_Histories_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Account_Histories_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Consensus_Account_Histories_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
@@ -14077,6 +14232,8 @@ export type Subscription_Root = {
   __typename?: 'subscription_root';
   /** fetch data from the table: "consensus.account_histories" */
   consensus_account_histories: Array<Consensus_Account_Histories>;
+  /** fetch aggregated fields from the table: "consensus.account_histories" */
+  consensus_account_histories_aggregate: Consensus_Account_Histories_Aggregate;
   /** fetch data from the table: "consensus.account_histories" using primary key columns */
   consensus_account_histories_by_pk?: Maybe<Consensus_Account_Histories>;
   /** fetch data from the table in a streaming manner: "consensus.account_histories" */
@@ -14443,6 +14600,15 @@ export type Subscription_Root = {
 
 
 export type Subscription_RootConsensus_Account_HistoriesArgs = {
+  distinct_on?: InputMaybe<Array<Consensus_Account_Histories_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Account_Histories_Order_By>>;
+  where?: InputMaybe<Consensus_Account_Histories_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Account_Histories_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Consensus_Account_Histories_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
@@ -15875,6 +16041,16 @@ export type TransfersByAccountIdQueryVariables = Exact<{
 
 
 export type TransfersByAccountIdQuery = { __typename?: 'query_root', consensus_transfers_aggregate: { __typename?: 'consensus_transfers_aggregate', aggregate?: { __typename?: 'consensus_transfers_aggregate_fields', count: number } | null }, consensus_transfers: Array<{ __typename?: 'consensus_transfers', id: string, extrinsic_id: string, event_id: string, from: string, to: string, value: any, fee: any, success: boolean, timestamp: any, date: any, created_at: any }> };
+
+export type BalanceHistoryByAccountIdQueryVariables = Exact<{
+  limit: Scalars['Int']['input'];
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<Consensus_Account_Histories_Bool_Exp>;
+  orderBy: Array<Consensus_Account_Histories_Order_By> | Consensus_Account_Histories_Order_By;
+}>;
+
+
+export type BalanceHistoryByAccountIdQuery = { __typename?: 'query_root', consensus_account_histories_aggregate: { __typename?: 'consensus_account_histories_aggregate', aggregate?: { __typename?: 'consensus_account_histories_aggregate_fields', count: number } | null }, consensus_account_histories: Array<{ __typename?: 'consensus_account_histories', reserved: any, total?: any | null, nonce: any, free: any, created_at: any, updated_at: any, _block_range: any, id: any }> };
 
 export type AllRewardForAccountByIdQueryVariables = Exact<{
   accountId: Scalars['String']['input'];

--- a/explorer/src/components/Consensus/Account/Account.tsx
+++ b/explorer/src/components/Consensus/Account/Account.tsx
@@ -21,6 +21,7 @@ import { AccountExtrinsicList } from './AccountExtrinsicList'
 import { AccountGraphs } from './AccountGraphs'
 import { AccountRewardsHistory } from './AccountRewardsHistory'
 import { AccountTransfersList } from './AccountTransfersList'
+import { BalanceHistory } from './BalanceHistory'
 import { QUERY_ACCOUNT_BY_ID } from './query'
 
 export const Account: FC = () => {
@@ -85,6 +86,9 @@ export const Account: FC = () => {
               </Tab>
               <Tab title='Transfers'>
                 <AccountTransfersList accountId={accountId} />
+              </Tab>
+              <Tab title='Balance History'>
+                <BalanceHistory accountId={accountId} />
               </Tab>
             </PageTabs>
           </>

--- a/explorer/src/components/Consensus/Account/BalanceHistory.tsx
+++ b/explorer/src/components/Consensus/Account/BalanceHistory.tsx
@@ -1,0 +1,203 @@
+/* eslint-disable camelcase */
+import { useApolloClient } from '@apollo/client'
+import { SortingState } from '@tanstack/react-table'
+import { SortedTable } from 'components/common/SortedTable'
+import { Spinner } from 'components/common/Spinner'
+import { Tooltip } from 'components/common/Tooltip'
+import { NotFound } from 'components/layout/NotFound'
+import { PAGE_SIZE } from 'constants/general'
+import { INTERNAL_ROUTES, Routes } from 'constants/routes'
+import { formatUnits } from 'ethers'
+import {
+  BalanceHistoryByAccountIdQuery,
+  BalanceHistoryByAccountIdQueryVariables,
+  Order_By as OrderBy,
+  Consensus_Transfers_Select_Column as TransferColumn,
+  Consensus_Transfers_Bool_Exp as TransferWhere,
+} from 'gql/graphql'
+import useChains from 'hooks/useChains'
+import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useWindowFocus } from 'hooks/useWindowFocus'
+import Link from 'next/link'
+import { FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { useInView } from 'react-intersection-observer'
+import type { Cell } from 'types/table'
+import { downloadFullData } from 'utils/downloadFullData'
+import { bigNumberToNumber } from 'utils/number'
+import { countTablePages } from 'utils/table'
+import { QUERY_ACCOUNT_BALANCE_HISTORY } from './query'
+
+type Props = {
+  accountId: string
+}
+
+type Row = BalanceHistoryByAccountIdQuery['consensus_account_histories'][0]
+
+export const BalanceHistory: FC<Props> = ({ accountId }) => {
+  const { ref, inView } = useInView()
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: TransferColumn.CreatedAt, desc: true },
+  ])
+  const [pagination, setPagination] = useState({
+    pageSize: PAGE_SIZE,
+    pageIndex: 0,
+  })
+  const { network, tokenSymbol } = useChains()
+  const apolloClient = useApolloClient()
+  const inFocus = useWindowFocus()
+
+  const orderBy = useMemo(
+    () =>
+      sorting && sorting.length > 0
+        ? sorting[0].id.endsWith('aggregate')
+          ? { [sorting[0].id]: sorting[0].desc ? { count: OrderBy.Desc } : { count: OrderBy.Asc } }
+          : { [sorting[0].id]: sorting[0].desc ? OrderBy.Desc : OrderBy.Asc }
+        : { id: OrderBy.Asc },
+    [sorting],
+  )
+
+  const where: TransferWhere = useMemo(() => ({ id: { _eq: accountId } }), [accountId])
+
+  const variables = useMemo(() => {
+    return {
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex > 0 ? pagination.pageIndex * pagination.pageSize : undefined,
+      orderBy,
+      where,
+    }
+  }, [orderBy, pagination.pageIndex, pagination.pageSize, where])
+
+  const { data, loading, setIsVisible } = useSquidQuery<
+    BalanceHistoryByAccountIdQuery,
+    BalanceHistoryByAccountIdQueryVariables
+  >(QUERY_ACCOUNT_BALANCE_HISTORY, {
+    variables,
+    skip: !inFocus,
+    pollInterval: 6000,
+  })
+
+  const fullDataDownloader = useCallback(
+    () =>
+      downloadFullData(apolloClient, QUERY_ACCOUNT_BALANCE_HISTORY, 'consensus_account_histories', {
+        orderBy,
+        where,
+      }),
+    [apolloClient, orderBy, where],
+  )
+
+  const histories = useMemo(() => data && data.consensus_account_histories, [data])
+  const totalCount = useMemo(
+    () =>
+      data && data.consensus_account_histories_aggregate
+        ? data.consensus_account_histories_aggregate.aggregate?.count
+        : 0,
+    [data],
+  )
+  const pageCount = useMemo(
+    () => (totalCount ? countTablePages(totalCount, pagination.pageSize) : 0),
+    [totalCount, pagination.pageSize],
+  )
+
+  const columns = useMemo(
+    () => [
+      {
+        accessorKey: 'created_at',
+        header: 'Block',
+        enableSorting: true,
+        cell: ({ row }: Cell<Row>) => (
+          <div key={`created_at-${row.original.id}`} className='row flex items-center gap-3'>
+            <Link
+              data-testid={`transfer-created_at-${row.index}`}
+              href={INTERNAL_ROUTES.blocks.id.page(
+                network,
+                Routes.consensus,
+                row.original.created_at,
+              )}
+              className='hover:text-primaryAccent'
+            >
+              <div>{row.original.created_at}</div>
+            </Link>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'nonce',
+        header: 'Nonce',
+        enableSorting: true,
+        cell: ({ row }: Cell<Row>) => (
+          <div key={`${row.original.id}-nonce-${row.index}`}>{row.original.nonce}</div>
+        ),
+      },
+      {
+        accessorKey: 'free',
+        header: 'Free',
+        enableSorting: true,
+        cell: ({ row }: Cell<Row>) => (
+          <div key={`${row.original.id}-free-${row.index}`}>
+            <Tooltip text={`${formatUnits(row.original.free)} ${tokenSymbol}`}>
+              {`${bigNumberToNumber(row.original.free, 6)} ${tokenSymbol}`}
+            </Tooltip>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'reserved',
+        header: 'Reserved',
+        enableSorting: true,
+        cell: ({ row }: Cell<Row>) => (
+          <div key={`${row.original.id}-reserved-${row.index}`}>
+            <Tooltip text={`${formatUnits(row.original.reserved)} ${tokenSymbol}`}>
+              {`${bigNumberToNumber(row.original.reserved, 6)} ${tokenSymbol}`}
+            </Tooltip>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'total',
+        header: 'Total',
+        enableSorting: true,
+        cell: ({ row }: Cell<Row>) => (
+          <div key={`${row.original.id}-total-${row.index}`}>
+            <Tooltip text={`${formatUnits(row.original.total)} ${tokenSymbol}`}>
+              {`${bigNumberToNumber(row.original.total, 6)} ${tokenSymbol}`}
+            </Tooltip>
+          </div>
+        ),
+      },
+    ],
+    [network, tokenSymbol],
+  )
+
+  const noData = useMemo(() => {
+    if (loading) return <Spinner isSmall />
+    if (!data) return <NotFound />
+    return null
+  }, [data, loading])
+
+  useEffect(() => {
+    setIsVisible(inView)
+  }, [inView, setIsVisible])
+
+  return (
+    <div className='flex w-full flex-col sm:mt-0'>
+      <div ref={ref}>
+        {!loading && histories ? (
+          <SortedTable
+            data={histories}
+            columns={columns}
+            showNavigation={true}
+            sorting={sorting}
+            onSortingChange={setSorting}
+            pagination={pagination}
+            pageCount={pageCount}
+            onPaginationChange={setPagination}
+            filename='account-balance-history'
+            fullDataDownloader={fullDataDownloader}
+          />
+        ) : (
+          noData
+        )}
+      </div>
+    </div>
+  )
+}

--- a/explorer/src/components/Consensus/Account/query.ts
+++ b/explorer/src/components/Consensus/Account/query.ts
@@ -179,6 +179,31 @@ export const QUERY_ACCOUNT_TRANSFERS = gql`
   }
 `
 
+export const QUERY_ACCOUNT_BALANCE_HISTORY = gql`
+  query BalanceHistoryByAccountId(
+    $limit: Int!
+    $offset: Int
+    $where: consensus_account_histories_bool_exp
+    $orderBy: [consensus_account_histories_order_by!]!
+  ) {
+    consensus_account_histories_aggregate(where: $where) {
+      aggregate {
+        count
+      }
+    }
+    consensus_account_histories(order_by: $orderBy, limit: $limit, offset: $offset, where: $where) {
+      id: uuid
+      reserved
+      total
+      nonce
+      free
+      created_at
+      updated_at
+      _block_range
+    }
+  }
+`
+
 export const QUERY_ALL_REWARDS_FOR_ACCOUNT_BY_ID = gql`
   query AllRewardForAccountById($accountId: String!) {
     consensus_rewards(where: { account_id: { _eq: $accountId }, amount: { _gt: 0 } }, limit: 1) {

--- a/indexers/db/metadata/databases/default/tables/consensus_account_histories.yaml
+++ b/indexers/db/metadata/databases/default/tables/consensus_account_histories.yaml
@@ -32,4 +32,5 @@ select_permissions:
         - id
         - _id
       filter: {}
+      allow_aggregations: true
     comment: ""


### PR DESCRIPTION
### **User description**
## Add account balance history

- Add a tab in account details to show the balance change of an account

### Screenshot

![Account Balance History](https://github.com/user-attachments/assets/46f7a5be-1eea-4a45-b56e-a55e4b42e42f)


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new 'Balance History' tab in the account details section to display the balance changes of an account.
- Implemented the `BalanceHistory` component which uses Apollo Client for fetching and displaying account balance data with sorting and pagination features.
- Introduced a new GraphQL query `QUERY_ACCOUNT_BALANCE_HISTORY` to retrieve balance history data.
- Updated database configuration to allow aggregations on the `consensus_account_histories` table.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Account.tsx</strong><dd><code>Add Balance History tab to account details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/Account.tsx

<li>Added a new tab for 'Balance History' in the account details.<br> <li> Imported <code>BalanceHistory</code> component.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/957/files#diff-c1e1c97b2238837cd4425fa878430ea87682d1e57d3f70d0c394e1413ba0a0a8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BalanceHistory.tsx</strong><dd><code>Implement BalanceHistory component for account balance tracking</code></dd></summary>
<hr>

explorer/src/components/Consensus/Account/BalanceHistory.tsx

<li>Implemented <code>BalanceHistory</code> component to display account balance <br>changes.<br> <li> Utilized Apollo Client for data fetching with sorting and pagination.<br> <li> Added table columns for balance details including 'Free', 'Reserved', <br>and 'Total'.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/957/files#diff-4b87a20823c6d33f6284ae35ca4d5bb9af5def72d42f8e3dfa3a26661ef5605b">+203/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query.ts</strong><dd><code>Add GraphQL query for account balance history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/query.ts

<li>Added GraphQL query <code>QUERY_ACCOUNT_BALANCE_HISTORY</code> for fetching balance <br>history.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/957/files#diff-34680083159c0630ee243dda507b8ca8383c08a4d8ed0aedfb2617a69bf2f08d">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consensus_account_histories.yaml</strong><dd><code>Allow aggregations in consensus_account_histories table</code>&nbsp; &nbsp; </dd></summary>
<hr>

indexers/db/metadata/databases/default/tables/consensus_account_histories.yaml

- Enabled aggregations for `consensus_account_histories` table.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/957/files#diff-ff9f6b925d443b9d15813c32c80ca0a8a0d563f2ea995f043b79bdeddad03bb0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information