### PR TITLE
Fix background svg

### DIFF
--- a/explorer/public/images/backgroundColor.svg
+++ b/explorer/public/images/backgroundColor.svg
@@ -1,5 +1,4 @@
 <svg width="2160" height="1872" viewBox="0 0 2160 1872" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="1920" height="1556" transform="translate(120 316)" fill="url(#paint0_linear_1_2)"/>
 <g filter="url(#filter0_f_1_2)">
 <rect x="888" y="210" width="510" height="510" rx="255" fill="#929EEA"/>
 <rect x="1146" y="120" width="510" height="510" rx="255" fill="#91D3A0"/>


### PR DESCRIPTION
## Fix background svg

This was showing black background on iOS, due to the fill property of the svg not been defined as per #959 

### Screenshot

<img width="358" alt="image" src="https://github.com/user-attachments/assets/b93cd4d7-7090-40ec-a00e-837b4d7e449f">
