### PR TITLE
Add missing mobile icons for new route and default icon

### DIFF
--- a/explorer/src/components/layout/SectionHeader.tsx
+++ b/explorer/src/components/layout/SectionHeader.tsx
@@ -1,6 +1,16 @@
 'use client'
 
-import { CpuChipIcon, GlobeAltIcon, QueueListIcon, TrophyIcon } from '@heroicons/react/24/outline'
+import {
+  CircleStackIcon,
+  CodeBracketIcon,
+  CpuChipIcon,
+  GiftIcon,
+  GlobeAltIcon,
+  IdentificationIcon,
+  LinkIcon,
+  QueueListIcon,
+  TrophyIcon,
+} from '@heroicons/react/24/outline'
 import { WalletButton } from 'components/WalletButton'
 import { WalletSidekick } from 'components/WalletSideKick'
 import { ROUTES, Routes } from 'constants/routes'
@@ -21,16 +31,24 @@ export const SectionHeader: FC = () => {
   const domainIcon = useCallback((domain: (typeof ROUTES)[0], isActive: boolean) => {
     const className = `w-6 h-6 ${isActive ? 'text-white' : 'text-grayDark'} dark:text-white`
     switch (domain.name) {
-      case Routes.nova:
-        return <GlobeAltIcon className={className} />
       case Routes.consensus:
         return <QueueListIcon className={className} />
+      case Routes.farming:
+        return <CpuChipIcon className={className} />
+      case Routes.staking:
+        return <CircleStackIcon className={className} />
       case Routes.leaderboard:
         return <TrophyIcon className={className} />
-      case Routes.staking:
-        return <CpuChipIcon className={className} />
+      case Routes.domains:
+        return <GlobeAltIcon className={className} />
+      case Routes.nova:
+        return <CodeBracketIcon className={className} />
+      case Routes.autoid:
+        return <IdentificationIcon className={className} />
+      case Routes.testnetRewards:
+        return <GiftIcon className={className} />
       default:
-        return null
+        return <LinkIcon className={className} />
     }
   }, [])
 


### PR DESCRIPTION
## Add missing mobile icons for new route and default icon

- Route had been removed or hidden for current network, and new route did not have any defined mobile icon
- Now there is a boring link icon as default if routes don't have a define icon

### Screenshot

<img width="351" alt="image" src="https://github.com/user-attachments/assets/9d2e9396-0deb-4370-a220-899f7fec9174">
