### PR TITLE
Remove consensus indexer offset logic

### DIFF
--- a/indexers/mainnet/consensus/src/mappings/helper.ts
+++ b/indexers/mainnet/consensus/src/mappings/helper.ts
@@ -1,10 +1,8 @@
-import { account, blockNumber } from "@autonomys/auto-consensus";
-import { ApiPromise, stringify } from "@autonomys/auto-utils";
+import { account } from "@autonomys/auto-consensus";
 import { SubstrateBlock } from "@subql/types";
 import { decodeLog } from "./utils";
 
 const DEFAULT_ACCOUNT_ID = "0x00";
-const DEFAULT_CHAIN_HEAD_OFFSET = 10;
 
 // Core Consensus Helper Functions
 
@@ -37,21 +35,3 @@ export const getBlockAuthor = (block: SubstrateBlock): string => {
 
 export const getAccountBalance = async (accountId: string) =>
   await account(api as any, accountId);
-
-export const preventIndexingTooCloseToTheHeadOfTheChain = async (
-  indexingBlockHeight: number | bigint
-) => {
-  if (!unsafeApi) throw new Error("Unsafe API not found");
-  if (
-    typeof indexingBlockHeight !== "number" &&
-    typeof indexingBlockHeight !== "bigint"
-  )
-    throw new Error("Indexing block height must be a number or bigint");
-  if (typeof indexingBlockHeight === "number")
-    indexingBlockHeight = BigInt(indexingBlockHeight);
-
-  const targetHeight = await blockNumber(unsafeApi as unknown as ApiPromise);
-
-  if (indexingBlockHeight > BigInt(targetHeight - DEFAULT_CHAIN_HEAD_OFFSET))
-    throw new Error("Indexing too close to the head of the chain, skipping...");
-};

--- a/indexers/mainnet/consensus/src/mappings/helper.ts
+++ b/indexers/mainnet/consensus/src/mappings/helper.ts
@@ -1,10 +1,7 @@
-import { account } from "@autonomys/auto-consensus";
 import { SubstrateBlock } from "@subql/types";
 import { decodeLog } from "./utils";
 
 const DEFAULT_ACCOUNT_ID = "0x00";
-
-// Core Consensus Helper Functions
 
 export const getBlockAuthor = (block: SubstrateBlock): string => {
   const { digest } = block.block.header;
@@ -30,8 +27,3 @@ export const getBlockAuthor = (block: SubstrateBlock): string => {
   }
   return DEFAULT_ACCOUNT_ID;
 };
-
-// Accounts Helper Functions
-
-export const getAccountBalance = async (accountId: string) =>
-  await account(api as any, accountId);

--- a/indexers/mainnet/consensus/src/mappings/mappingAccountHandlers.ts
+++ b/indexers/mainnet/consensus/src/mappings/mappingAccountHandlers.ts
@@ -1,10 +1,10 @@
+import { account } from "@autonomys/auto-consensus";
 import { SubstrateEvent, SubstrateExtrinsic } from "@subql/types";
 import {
   createAndSaveAccountHistory,
   createAndSaveReward,
   createAndSaveTransfer,
 } from "./db";
-import { getAccountBalance } from "./helper";
 
 export async function handleTransferEvent(
   event: SubstrateEvent
@@ -20,8 +20,8 @@ export async function handleTransferEvent(
   const to = _to.toString();
   const amount = BigInt(_amount.toString());
 
-  const fromBalance = await getAccountBalance(from);
-  const toBalance = await getAccountBalance(to);
+  const fromBalance = await account(api as any, from);
+  const toBalance = await account(api as any, to);
 
   // create or update and save accounts
   await createAndSaveAccountHistory(
@@ -69,7 +69,7 @@ export async function handleExtrinsic(
   const blockNumber = BigInt(number.toString());
   const address = signer.toString();
 
-  const balance = await getAccountBalance(address);
+  const balance = await account(api as any, address);
 
   // create or update and save accounts
   await createAndSaveAccountHistory(
@@ -103,7 +103,7 @@ export async function handleFarmerVoteRewardEvent(
   const voter = _voter.toString();
   const blockNumber = BigInt(number.toString());
 
-  const balance = await getAccountBalance(voter);
+  const balance = await account(api as any, voter);
 
   // create or update and save accounts
   await createAndSaveAccountHistory(
@@ -147,7 +147,7 @@ export async function handleFarmerBlockRewardEvent(
   const blockAuthor = _blockAuthor.toString();
   const blockNumber = BigInt(number.toString());
 
-  const balance = await getAccountBalance(blockAuthor);
+  const balance = await account(api as any, blockAuthor);
 
   // create or update and save accounts
   await createAndSaveAccountHistory(

--- a/indexers/mainnet/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/mainnet/consensus/src/mappings/mappingHandlers.ts
@@ -12,10 +12,7 @@ import {
   createAndSaveExtrinsic,
   createAndSaveLog,
 } from "./db";
-import {
-  getBlockAuthor,
-  preventIndexingTooCloseToTheHeadOfTheChain,
-} from "./helper";
+import { getBlockAuthor } from "./helper";
 import {
   handleExtrinsic,
   handleFarmerBlockRewardEvent,
@@ -42,8 +39,6 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
     events,
   } = _block;
   const height = BigInt(number.toString());
-  await preventIndexingTooCloseToTheHeadOfTheChain(height);
-
   const blockHash = hash.toString();
   const blockTimestamp = timestamp ? timestamp : new Date(0);
   // Get block author
@@ -112,9 +107,6 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
     success,
     events,
   } = _call;
-  const height = BigInt(number.toString());
-  await preventIndexingTooCloseToTheHeadOfTheChain(height);
-
   const methodToHuman = method.toHuman() as ExtrinsicHuman;
   const methodToPrimitive = method.toPrimitive() as ExtrinsicPrimitive;
   const eventRecord = events[idx];
@@ -143,7 +135,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
 
   await createAndSaveExtrinsic(
     hash.toString(),
-    height,
+    BigInt(number.toString()),
     hash.toString(),
     idx,
     methodToHuman.section,
@@ -176,9 +168,6 @@ export async function handleEvent(_event: SubstrateEvent): Promise<void> {
     extrinsic,
     event,
   } = _event;
-  const height = BigInt(number.toString());
-  await preventIndexingTooCloseToTheHeadOfTheChain(height);
-
   const primitive = event.toPrimitive() as EventPrimitive;
   const human = event.toHuman() as EventHuman;
 
@@ -194,7 +183,7 @@ export async function handleEvent(_event: SubstrateEvent): Promise<void> {
   const extrinsicHash = extrinsic ? extrinsic.extrinsic.hash.toString() : "";
 
   await createAndSaveEvent(
-    height,
+    BigInt(number.toString()),
     hash.toString(),
     BigInt(idx),
     extrinsicId,

--- a/indexers/taurus/consensus/src/mappings/helper.ts
+++ b/indexers/taurus/consensus/src/mappings/helper.ts
@@ -1,10 +1,8 @@
-import { account, blockNumber } from "@autonomys/auto-consensus";
-import { ApiPromise, stringify } from "@autonomys/auto-utils";
+import { account } from "@autonomys/auto-consensus";
 import { SubstrateBlock } from "@subql/types";
 import { decodeLog } from "./utils";
 
 const DEFAULT_ACCOUNT_ID = "0x00";
-const DEFAULT_CHAIN_HEAD_OFFSET = 10;
 
 // Core Consensus Helper Functions
 
@@ -37,21 +35,3 @@ export const getBlockAuthor = (block: SubstrateBlock): string => {
 
 export const getAccountBalance = async (accountId: string) =>
   await account(api as any, accountId);
-
-export const preventIndexingTooCloseToTheHeadOfTheChain = async (
-  indexingBlockHeight: number | bigint
-) => {
-  if (!unsafeApi) throw new Error("Unsafe API not found");
-  if (
-    typeof indexingBlockHeight !== "number" &&
-    typeof indexingBlockHeight !== "bigint"
-  )
-    throw new Error("Indexing block height must be a number or bigint");
-  if (typeof indexingBlockHeight === "number")
-    indexingBlockHeight = BigInt(indexingBlockHeight);
-
-  const targetHeight = await blockNumber(unsafeApi as unknown as ApiPromise);
-
-  if (indexingBlockHeight > BigInt(targetHeight - DEFAULT_CHAIN_HEAD_OFFSET))
-    throw new Error("Indexing too close to the head of the chain, skipping...");
-};

--- a/indexers/taurus/consensus/src/mappings/helper.ts
+++ b/indexers/taurus/consensus/src/mappings/helper.ts
@@ -1,10 +1,7 @@
-import { account } from "@autonomys/auto-consensus";
 import { SubstrateBlock } from "@subql/types";
 import { decodeLog } from "./utils";
 
 const DEFAULT_ACCOUNT_ID = "0x00";
-
-// Core Consensus Helper Functions
 
 export const getBlockAuthor = (block: SubstrateBlock): string => {
   const { digest } = block.block.header;
@@ -30,8 +27,3 @@ export const getBlockAuthor = (block: SubstrateBlock): string => {
   }
   return DEFAULT_ACCOUNT_ID;
 };
-
-// Accounts Helper Functions
-
-export const getAccountBalance = async (accountId: string) =>
-  await account(api as any, accountId);

--- a/indexers/taurus/consensus/src/mappings/mappingAccountHandlers.ts
+++ b/indexers/taurus/consensus/src/mappings/mappingAccountHandlers.ts
@@ -1,10 +1,10 @@
+import { account } from "@autonomys/auto-consensus";
 import { SubstrateEvent, SubstrateExtrinsic } from "@subql/types";
 import {
   createAndSaveAccountHistory,
   createAndSaveReward,
   createAndSaveTransfer,
 } from "./db";
-import { getAccountBalance } from "./helper";
 
 export async function handleTransferEvent(
   event: SubstrateEvent
@@ -20,8 +20,8 @@ export async function handleTransferEvent(
   const to = _to.toString();
   const amount = BigInt(_amount.toString());
 
-  const fromBalance = await getAccountBalance(from);
-  const toBalance = await getAccountBalance(to);
+  const fromBalance = await account(api as any, from);
+  const toBalance = await account(api as any, to);
 
   // create or update and save accounts
   await createAndSaveAccountHistory(
@@ -69,7 +69,7 @@ export async function handleExtrinsic(
   const blockNumber = BigInt(number.toString());
   const address = signer.toString();
 
-  const balance = await getAccountBalance(address);
+  const balance = await account(api as any, address);
 
   // create or update and save accounts
   await createAndSaveAccountHistory(
@@ -103,7 +103,7 @@ export async function handleFarmerVoteRewardEvent(
   const voter = _voter.toString();
   const blockNumber = BigInt(number.toString());
 
-  const balance = await getAccountBalance(voter);
+  const balance = await account(api as any, voter);
 
   // create or update and save accounts
   await createAndSaveAccountHistory(
@@ -147,7 +147,7 @@ export async function handleFarmerBlockRewardEvent(
   const blockAuthor = _blockAuthor.toString();
   const blockNumber = BigInt(number.toString());
 
-  const balance = await getAccountBalance(blockAuthor);
+  const balance = await account(api as any, blockAuthor);
 
   // create or update and save accounts
   await createAndSaveAccountHistory(

--- a/indexers/taurus/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/taurus/consensus/src/mappings/mappingHandlers.ts
@@ -12,10 +12,7 @@ import {
   createAndSaveExtrinsic,
   createAndSaveLog,
 } from "./db";
-import {
-  getBlockAuthor,
-  preventIndexingTooCloseToTheHeadOfTheChain,
-} from "./helper";
+import { getBlockAuthor } from "./helper";
 import {
   handleExtrinsic,
   handleFarmerBlockRewardEvent,
@@ -42,8 +39,6 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
     events,
   } = _block;
   const height = BigInt(number.toString());
-  await preventIndexingTooCloseToTheHeadOfTheChain(height);
-
   const blockHash = hash.toString();
   const blockTimestamp = timestamp ? timestamp : new Date(0);
   // Get block author
@@ -112,9 +107,6 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
     success,
     events,
   } = _call;
-  const height = BigInt(number.toString());
-  await preventIndexingTooCloseToTheHeadOfTheChain(height);
-
   const methodToHuman = method.toHuman() as ExtrinsicHuman;
   const methodToPrimitive = method.toPrimitive() as ExtrinsicPrimitive;
   const eventRecord = events[idx];
@@ -143,7 +135,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
 
   await createAndSaveExtrinsic(
     hash.toString(),
-    height,
+    BigInt(number.toString()),
     hash.toString(),
     idx,
     methodToHuman.section,
@@ -176,9 +168,6 @@ export async function handleEvent(_event: SubstrateEvent): Promise<void> {
     extrinsic,
     event,
   } = _event;
-  const height = BigInt(number.toString());
-  await preventIndexingTooCloseToTheHeadOfTheChain(height);
-
   const primitive = event.toPrimitive() as EventPrimitive;
   const human = event.toHuman() as EventHuman;
 
@@ -194,7 +183,7 @@ export async function handleEvent(_event: SubstrateEvent): Promise<void> {
   const extrinsicHash = extrinsic ? extrinsic.extrinsic.hash.toString() : "";
 
   await createAndSaveEvent(
-    height,
+    BigInt(number.toString()),
     hash.toString(),
     BigInt(idx),
     extrinsicId,


### PR DESCRIPTION
### **User description**
## Remove consensus indexer offset logic

The recent changes we made between consensus&leaderboard indexers and the taskboard result in no need for a offset anymore. SubQuery indexer does manage fork, so if there is a re-org, it will drop the old row and re-write these blocks in the db.

The Taskboard on its side refresh the consensus unique row table (mainly accounts) every minute, and leaderboard unique row tables every 2 minutes. In both case it simply grab the last unique row from the tables it's feed on, so if there is a re-org, 1 or 2 minutes later, the leaderboard will be updated.

Ultimately, we now have historical tables for the leaderboard, so we could extract the leaderboard position at a specific blocks, allowing full traceability and snapshot capacity.

- Remove 10 blocks offset logic on consensus indexer
- Simplify logic around account update


___

### **PR Type**
enhancement


___

### **Description**
- Removed the consensus indexer offset logic by deleting the `DEFAULT_CHAIN_HEAD_OFFSET` constant and the `preventIndexingTooCloseToTheHeadOfTheChain` function from helper files.
- Simplified account balance retrieval by replacing `getAccountBalance` with direct `account` function calls in mapping account handlers.
- Removed unnecessary checks for indexing too close to the head of the chain in mapping handlers.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helper.ts</strong><dd><code>Remove offset logic and unused functions from helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/mainnet/consensus/src/mappings/helper.ts

<li>Removed the <code>DEFAULT_CHAIN_HEAD_OFFSET</code> constant.<br> <li> Deleted the <code>preventIndexingTooCloseToTheHeadOfTheChain</code> function.<br> <li> Removed the <code>getAccountBalance</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/966/files#diff-bb89264c0d5f9ce91dabc9829447614458ba1b4cd46cbefef00a2fc1285491c1">+0/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mappingAccountHandlers.ts</strong><dd><code>Simplify account balance retrieval in mapping handlers</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/mainnet/consensus/src/mappings/mappingAccountHandlers.ts

- Replaced `getAccountBalance` with direct `account` function calls.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/966/files#diff-29f1fa1a17e651eac364f24247dd3f6efb0bee5116d2285841da195480891810">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mappingHandlers.ts</strong><dd><code>Remove chain head offset checks in mapping handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/mainnet/consensus/src/mappings/mappingHandlers.ts

- Removed calls to `preventIndexingTooCloseToTheHeadOfTheChain`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/966/files#diff-0e35352c284b64517989efc02c193bfc5af2ff26f7946cba711e0113e4440836">+3/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>helper.ts</strong><dd><code>Remove offset logic and unused functions from helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/taurus/consensus/src/mappings/helper.ts

<li>Removed the <code>DEFAULT_CHAIN_HEAD_OFFSET</code> constant.<br> <li> Deleted the <code>preventIndexingTooCloseToTheHeadOfTheChain</code> function.<br> <li> Removed the <code>getAccountBalance</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/966/files#diff-f0ffacaa27f2236bc750ead02caf99cd374df87d2a9102a7250742856250fb02">+0/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mappingAccountHandlers.ts</strong><dd><code>Simplify account balance retrieval in mapping handlers</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/taurus/consensus/src/mappings/mappingAccountHandlers.ts

- Replaced `getAccountBalance` with direct `account` function calls.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/966/files#diff-ef2d46660eb105542a75c3b462bf00883a51155ad5151b8bfcb11268f8885491">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mappingHandlers.ts</strong><dd><code>Remove chain head offset checks in mapping handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/taurus/consensus/src/mappings/mappingHandlers.ts

- Removed calls to `preventIndexingTooCloseToTheHeadOfTheChain`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/966/files#diff-3086b8218297f23584fbf57779c7f481b6232a502cc3bfa52ae3a2e57f0ba920">+3/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information