### PR TITLE
Use block hash instead of extrinsic hash in extrinsic table for extrinsic hash

### DIFF
--- a/indexers/mainnet/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/mainnet/consensus/src/mappings/mappingHandlers.ts
@@ -100,7 +100,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
     block: {
       timestamp,
       block: {
-        header: { number },
+        header: { number, hash: blockHash },
       },
     },
     extrinsic: { method, hash, nonce, signer, signature, tip },
@@ -136,7 +136,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
   await createAndSaveExtrinsic(
     hash.toString(),
     BigInt(number.toString()),
-    hash.toString(),
+    blockHash.toString(),
     idx,
     methodToHuman.section,
     methodToHuman.method,

--- a/indexers/taurus/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/taurus/consensus/src/mappings/mappingHandlers.ts
@@ -100,7 +100,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
     block: {
       timestamp,
       block: {
-        header: { number },
+        header: { number, hash: blockHash },
       },
     },
     extrinsic: { method, hash, nonce, signer, signature, tip },
@@ -136,7 +136,7 @@ export async function handleCall(_call: SubstrateExtrinsic): Promise<void> {
   await createAndSaveExtrinsic(
     hash.toString(),
     BigInt(number.toString()),
-    hash.toString(),
+    blockHash.toString(),
     idx,
     methodToHuman.section,
     methodToHuman.method,


### PR DESCRIPTION
### **User description**
## Use block hash instead of extrinsic hash in extrinsic table for extrinsic hash

While doing change to our indexers, I notice the error, I was using extrinsinsic hash for the block hash in the extrinsic mapping


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected the usage of block hash instead of extrinsic hash in the `createAndSaveExtrinsic` function for both `mainnet` and `taurus` indexers.
- Updated the block header extraction to include the block hash in the `handleCall` function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mappingHandlers.ts</strong><dd><code>Fix block hash usage in extrinsic mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/mainnet/consensus/src/mappings/mappingHandlers.ts

<li>Replaced the use of extrinsic hash with block hash in the <br><code>createAndSaveExtrinsic</code> function call.<br> <li> Updated the block header extraction to include block hash.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/978/files#diff-0e35352c284b64517989efc02c193bfc5af2ff26f7946cba711e0113e4440836">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mappingHandlers.ts</strong><dd><code>Fix block hash usage in extrinsic mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/taurus/consensus/src/mappings/mappingHandlers.ts

<li>Replaced the use of extrinsic hash with block hash in the <br><code>createAndSaveExtrinsic</code> function call.<br> <li> Updated the block header extraction to include block hash.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/978/files#diff-3086b8218297f23584fbf57779c7f481b6232a502cc3bfa52ae3a2e57f0ba920">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information