### PR TITLE
Use consensus account histories for account detail page

### DIFF
--- a/explorer/gql/graphql.ts
+++ b/explorer/gql/graphql.ts
@@ -16004,7 +16004,7 @@ export type AccountByIdQueryVariables = Exact<{
 }>;
 
 
-export type AccountByIdQuery = { __typename?: 'query_root', consensus_account_histories: Array<{ __typename?: 'consensus_account_histories', free: any, reserved: any, total?: any | null, nonce: any }>, consensus_rewards: Array<{ __typename?: 'consensus_rewards', index_in_block: any, amount: any, timestamp: any, blockHeight: any, rewardType: string }> };
+export type AccountByIdQuery = { __typename?: 'query_root', consensus_account_histories: Array<{ __typename?: 'consensus_account_histories', id: string, free: any, reserved: any, total?: any | null, nonce: any }>, consensus_rewards: Array<{ __typename?: 'consensus_rewards', id: string, amount: any, timestamp: any, blockHeight: any, rewardType: string }> };
 
 export type LatestRewardsWeekQueryVariables = Exact<{
   accountId: Scalars['String']['input'];

--- a/explorer/gql/graphql.ts
+++ b/explorer/gql/graphql.ts
@@ -16004,7 +16004,7 @@ export type AccountByIdQueryVariables = Exact<{
 }>;
 
 
-export type AccountByIdQuery = { __typename?: 'query_root', consensus_accounts: Array<{ __typename?: 'consensus_accounts', id: string, free: any, reserved: any, total?: any | null, nonce: any, updated_at: any, extrinsics: Array<{ __typename?: 'consensus_extrinsics', hash: string, id: string, index_in_block: number, name: string, success: boolean, timestamp: any, tip: any, block?: { __typename?: 'consensus_blocks', id: string, height: any } | null }> }>, consensus_rewards: Array<{ __typename?: 'consensus_rewards', id: string, index_in_block: any, amount: any, timestamp: any, blockHeight: any, rewardType: string }> };
+export type AccountByIdQuery = { __typename?: 'query_root', consensus_account_histories: Array<{ __typename?: 'consensus_account_histories', free: any, reserved: any, total?: any | null, nonce: any }>, consensus_rewards: Array<{ __typename?: 'consensus_rewards', index_in_block: any, amount: any, timestamp: any, blockHeight: any, rewardType: string }> };
 
 export type LatestRewardsWeekQueryVariables = Exact<{
   accountId: Scalars['String']['input'];

--- a/explorer/src/app/[chain]/consensus/accounts/[accountId]/image/route.tsx
+++ b/explorer/src/app/[chain]/consensus/accounts/[accountId]/image/route.tsx
@@ -10,7 +10,6 @@ import { NextRequest } from 'next/server'
 import { AccountIdPageProps, ChainPageProps } from 'types/app'
 import { getTokenSymbol } from 'utils/network'
 import { bigNumberToNumber, numberWithCommas } from 'utils/number'
-import { utcToLocalRelativeTime } from 'utils/time'
 
 // export const runtime = 'edge'
 export async function GET(
@@ -25,7 +24,7 @@ export async function GET(
   if (!accountId || !chainMatch) notFound()
 
   const {
-    data: { consensus_accounts: accountById },
+    data: { consensus_account_histories: accountById },
   }: {
     data: AccountByIdQuery
   } = await fetch(chainMatch.indexer, {
@@ -70,7 +69,7 @@ function Screen({
 }: {
   chainMatch: (typeof indexers)[number]
   accountId: string
-  accountById: AccountByIdQuery['consensus_accounts'][number]
+  accountById: AccountByIdQuery['consensus_account_histories'][number]
   tokenSymbol: string
 }) {
   const account = {
@@ -79,7 +78,6 @@ function Screen({
     reserved: accountById?.reserved ?? '0',
     nonce: accountById?.nonce ?? '0',
   }
-  const lastExtrinsic = accountById?.extrinsics[0]
   const title = `${metadata.title} - ${chainMatch.title} - Account`
 
   return (
@@ -169,35 +167,6 @@ function Screen({
             >
               Total nonces used {numberWithCommas(account.nonce)}
             </span>
-            {lastExtrinsic ? (
-              <div tw='absolute flex flex-col'>
-                <span
-                  style={{
-                    fontFamily: 'Montserrat',
-                  }}
-                  tw='absolute text-xl text-white p-4 ml-30 mt-8 font-bold'
-                >
-                  Last extrinsic {lastExtrinsic.name.split('.')[1].toUpperCase()}
-                </span>
-                <span
-                  style={{
-                    fontFamily: 'Montserrat',
-                  }}
-                  tw='absolute text-xl text-white p-4 ml-30 mt-16 font-bold'
-                >
-                  {utcToLocalRelativeTime(lastExtrinsic.timestamp)}
-                </span>
-              </div>
-            ) : (
-              <span
-                style={{
-                  fontFamily: 'Montserrat',
-                }}
-                tw='absolute text-xl text-white p-4 ml-30 mt-16 font-bold'
-              >
-                This account has no extrinsics
-              </span>
-            )}
           </div>
         </div>
       </div>

--- a/explorer/src/components/Consensus/Account/Account.tsx
+++ b/explorer/src/components/Consensus/Account/Account.tsx
@@ -49,7 +49,7 @@ export const Account: FC = () => {
     if (hasValue(consensusEntry)) return consensusEntry.value
   }, [consensusEntry])
 
-  const account = useMemo(() => data && data.consensus_accounts[0], [data])
+  const account = useMemo(() => data && data.consensus_account_histories[0], [data])
   const rewards = useMemo(() => (data ? data.consensus_rewards : []), [data])
 
   useEffect(() => {

--- a/explorer/src/components/Consensus/Account/AccountBalancePieChart.tsx
+++ b/explorer/src/components/Consensus/Account/AccountBalancePieChart.tsx
@@ -5,7 +5,7 @@ import { FC } from 'react'
 import { bigNumberToNumber } from 'utils/number'
 
 type Props = {
-  account: AccountByIdQuery['consensus_accounts'][number] | undefined
+  account: AccountByIdQuery['consensus_account_histories'][number] | undefined
 }
 
 export const AccountBalancePieChart: FC<Props> = ({ account }) => {

--- a/explorer/src/components/Consensus/Account/AccountBalanceStats.tsx
+++ b/explorer/src/components/Consensus/Account/AccountBalanceStats.tsx
@@ -6,7 +6,7 @@ import { bigNumberToNumber, numberWithCommas } from 'utils/number'
 import { AccountBalancePieChart } from './AccountBalancePieChart'
 
 type Props = {
-  account: AccountByIdQuery['consensus_accounts'][number] | undefined
+  account: AccountByIdQuery['consensus_account_histories'][number] | undefined
   isDesktop?: boolean
 }
 

--- a/explorer/src/components/Consensus/Account/AccountDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Account/AccountDetailsCard.tsx
@@ -10,7 +10,7 @@ import { accountIdToHex } from 'utils//formatAddress'
 import { AccountIcon } from '../../common/AccountIcon'
 
 type Props = {
-  account: AccountByIdQuery['consensus_accounts'][number] | undefined
+  account: AccountByIdQuery['consensus_account_histories'][number] | undefined
   accountAddress: string
   isDesktop?: boolean
 }

--- a/explorer/src/components/Consensus/Account/AccountGraphs.tsx
+++ b/explorer/src/components/Consensus/Account/AccountGraphs.tsx
@@ -5,7 +5,7 @@ import { AccountBalanceStats } from './AccountBalanceStats'
 import { AccountGraphTabs } from './AccountGraphTabs'
 
 type Props = {
-  account: AccountByIdQuery['consensus_accounts'][number] | undefined
+  account: AccountByIdQuery['consensus_account_histories'][number] | undefined
   isDesktop?: boolean
 }
 

--- a/explorer/src/components/Consensus/Account/AccountRewardList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardList.tsx
@@ -92,7 +92,9 @@ export const AccountRewardList: FC = () => {
   const totalLabel = useMemo(() => numberWithCommas(Number(totalCount)), [totalCount])
 
   const account = useMemo(
-    () => rewards && (rewards[0].account as AccountByIdQuery['consensus_accounts'][number]),
+    () =>
+      rewards &&
+      (rewards[0].account as unknown as AccountByIdQuery['consensus_account_histories'][number]),
     [rewards],
   )
   const convertedAddress = useMemo(() => (account ? formatAddress(account.id) : ''), [account])

--- a/explorer/src/components/Consensus/Account/query.ts
+++ b/explorer/src/components/Consensus/Account/query.ts
@@ -36,6 +36,7 @@ export const QUERY_ACCOUNT_BY_ID = gql`
       limit: 1
       order_by: { _block_range: desc }
     ) {
+      id
       free
       reserved
       total
@@ -46,6 +47,7 @@ export const QUERY_ACCOUNT_BY_ID = gql`
       order_by: { block_height: desc }
       where: { account_id: { _eq: $accountId }, amount: { _gt: 0 } }
     ) {
+      id
       blockHeight: block_height
       rewardType: reward_type
       amount

--- a/explorer/src/components/Consensus/Account/query.ts
+++ b/explorer/src/components/Consensus/Account/query.ts
@@ -31,35 +31,22 @@ export const QUERY_ACCOUNTS = gql`
 
 export const QUERY_ACCOUNT_BY_ID = gql`
   query AccountById($accountId: String!) {
-    consensus_accounts(where: { id: { _eq: $accountId } }) {
-      id
+    consensus_account_histories(
+      where: { id: { _eq: $accountId } }
+      limit: 1
+      order_by: { _block_range: desc }
+    ) {
       free
       reserved
       total
       nonce
-      updated_at
-      extrinsics(limit: 10, order_by: { block_height: desc }) {
-        hash
-        id
-        index_in_block
-        name
-        success
-        timestamp
-        tip
-        block {
-          id
-          height
-        }
-      }
     }
     consensus_rewards(
       limit: 10
       order_by: { block_height: desc }
       where: { account_id: { _eq: $accountId }, amount: { _gt: 0 } }
     ) {
-      id
       blockHeight: block_height
-      index_in_block
       rewardType: reward_type
       amount
       timestamp


### PR DESCRIPTION
### **User description**
## Use consensus account histories for account detail page

There is an issue with my task that try to update all the accounts row in the taskboard, likely too many row to look at, I switched the query and detail page to look at the last row in account_histories.

This has the advantage to not suffer from any lags.


___

### **PR Type**
Enhancement


___

### **Description**
- Updated the account detail page to use `consensus_account_histories` instead of `consensus_accounts`.
- Removed extrinsics from the account data structure and related UI components.
- Adjusted various components to accommodate the new data structure.
- Improved performance by querying only the latest account history entry.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>graphql.ts</strong><dd><code>Update account query to use consensus account histories</code>&nbsp; &nbsp; </dd></summary>
<hr>

explorer/gql/graphql.ts

<li>Changed the query to use <code>consensus_account_histories</code> instead of <br><code>consensus_accounts</code>.<br> <li> Removed extrinsics from the account query.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/987/files#diff-bc0e46e46459f8be09a193e520663a980b0e3512600117b0db7772f0d66a1290">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.tsx</strong><dd><code>Adapt account detail route to new data structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/app/[chain]/consensus/accounts/[accountId]/image/route.tsx

<li>Updated data fetching to use <code>consensus_account_histories</code>.<br> <li> Removed handling of extrinsics in the account data.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/987/files#diff-7e53da239cb9a3f12f0eb9accd410fe5a6f9a8265c96bd58317f87877608e2eb">+2/-33</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Account.tsx</strong><dd><code>Update account component to use new data source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/Account.tsx

- Updated account data reference to `consensus_account_histories`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/987/files#diff-c1e1c97b2238837cd4425fa878430ea87682d1e57d3f70d0c394e1413ba0a0a8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountBalancePieChart.tsx</strong><dd><code>Update pie chart component for new account data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountBalancePieChart.tsx

- Changed account prop type to `consensus_account_histories`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/987/files#diff-7f2e0f3ea6f102ca2b6fd56838f2765ae38d629aeb7a9dc6e73a58ce90535afe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountBalanceStats.tsx</strong><dd><code>Update balance stats component for new account data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountBalanceStats.tsx

- Changed account prop type to `consensus_account_histories`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/987/files#diff-fce164239457682949590c3fe9f5a5c9aab637655afb22388a442b82d20ef279">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountDetailsCard.tsx</strong><dd><code>Update details card component for new account data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountDetailsCard.tsx

- Changed account prop type to `consensus_account_histories`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/987/files#diff-6d78795a8ba4f5c57c45868a8a37efc2ce7396f2ce7337b2951ddc571cfec108">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountGraphs.tsx</strong><dd><code>Update graphs component for new account data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountGraphs.tsx

- Changed account prop type to `consensus_account_histories`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/987/files#diff-ef307efb7dfd878c4875c6db2b41e98399fd1e8d38225f894655960452630a86">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountRewardList.tsx</strong><dd><code>Update reward list component for new account data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountRewardList.tsx

- Updated account type casting to `consensus_account_histories`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/987/files#diff-f0dd9aa976a027f4dafc25bbf6042592aa1b4612ee8f3e6c7e567e6a537a57b1">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query.ts</strong><dd><code>Modify account query to use consensus account histories</code>&nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/query.ts

<li>Modified the account query to use <code>consensus_account_histories</code>.<br> <li> Removed extrinsics from the query.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/987/files#diff-34680083159c0630ee243dda507b8ca8383c08a4d8ed0aedfb2617a69bf2f08d">+5/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information