### PR TITLE
Improve Apollo config

### DIFF
--- a/explorer/src/app/api/log/[...params]/route.ts
+++ b/explorer/src/app/api/log/[...params]/route.ts
@@ -16,14 +16,14 @@ export const POST = async (req: NextRequest) => {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `Path: ${req.nextUrl.pathname}`,
+          text: `Path: ${req.nextUrl.pathname.replace('/api/log/', '')}`,
         },
       },
       {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `\`\`\`${JSON.stringify(logData, null, 2).slice(0, 25000)}\`\`\``,
+          text: `\`\`\`${JSON.stringify(logData, null, 2).slice(0, 5000)}\`\`\``,
         },
       },
     ])

--- a/explorer/src/components/Consensus/Account/Account.tsx
+++ b/explorer/src/components/Consensus/Account/Account.tsx
@@ -7,8 +7,8 @@ import { Tab } from 'components/common/Tabs'
 import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import { AccountByIdQuery, AccountByIdQueryVariables } from 'gql/graphql'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useMediaQuery from 'hooks/useMediaQuery'
-import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useParams } from 'next/navigation'
 import { FC, useEffect, useMemo } from 'react'
@@ -31,7 +31,7 @@ export const Account: FC = () => {
   const accountId = formatAddress(rawAccountId)
   const isDesktop = useMediaQuery('(min-width: 1024px)')
 
-  const { loading, setIsVisible } = useSquidQuery<AccountByIdQuery, AccountByIdQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<AccountByIdQuery, AccountByIdQueryVariables>(
     QUERY_ACCOUNT_BY_ID,
     {
       variables: { accountId: accountId ?? '' },

--- a/explorer/src/components/Consensus/Account/AccountBalanceStats.tsx
+++ b/explorer/src/components/Consensus/Account/AccountBalanceStats.tsx
@@ -1,6 +1,6 @@
 import { StatItem } from 'components/common/StatItem'
 import { AccountByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { FC } from 'react'
 import { bigNumberToNumber, numberWithCommas } from 'utils/number'
 import { AccountBalancePieChart } from './AccountBalancePieChart'
@@ -16,7 +16,7 @@ export const AccountBalanceStats: FC<Props> = ({ account, isDesktop = false }) =
   const accountReserved = bigNumberToNumber(account ? account.reserved : 0)
   const freePercent = accountTotal ? (100 * accountFree) / accountTotal : 0
   const reservedPercent = accountTotal ? (100 * accountReserved) / accountTotal : 0
-  const { tokenSymbol } = useChains()
+  const { tokenSymbol } = useIndexers()
 
   const backgroundStyle = !isDesktop
     ? 'dark:bg-gradient-to-r dark:from-gradientFrom dark:via-gradientVia dark:to-gradientTo rounded-[20px]'

--- a/explorer/src/components/Consensus/Account/AccountDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Account/AccountDetailsCard.tsx
@@ -4,7 +4,7 @@ import { CopyButton } from 'components/common/CopyButton'
 import { List, StyledListItem } from 'components/common/List'
 import { Routes } from 'constants/routes'
 import { AccountByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { FC } from 'react'
 import { accountIdToHex } from 'utils//formatAddress'
 import { AccountIcon } from '../../common/AccountIcon'
@@ -17,7 +17,7 @@ type Props = {
 
 export const AccountDetailsCard: FC<Props> = ({ account, accountAddress, isDesktop = false }) => {
   const publicKey = accountIdToHex(accountAddress)
-  const { section } = useChains()
+  const { section } = useIndexers()
 
   const theme = section === Routes.nova ? 'ethereum' : 'beachball'
   return (

--- a/explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx
@@ -13,7 +13,7 @@ import {
   ExtrinsicsByAccountIdQueryVariables,
   Order_By as OrderBy,
 } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -40,7 +40,7 @@ export const AccountExtrinsicList: FC<Props> = ({ accountId }) => {
     pageIndex: 0,
   })
 
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const apolloClient = useApolloClient()
   const inFocus = useWindowFocus()
 

--- a/explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx
@@ -14,7 +14,7 @@ import {
   Order_By as OrderBy,
 } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -63,7 +63,7 @@ export const AccountExtrinsicList: FC<Props> = ({ accountId }) => {
     }
   }, [orderBy, pagination.pageIndex, pagination.pageSize, where])
 
-  const { loading, setIsVisible } = useSquidQuery<
+  const { loading, setIsVisible } = useIndexersQuery<
     ExtrinsicsByAccountIdQuery,
     ExtrinsicsByAccountIdQueryVariables
   >(

--- a/explorer/src/components/Consensus/Account/AccountGraphTabs.tsx
+++ b/explorer/src/components/Consensus/Account/AccountGraphTabs.tsx
@@ -1,5 +1,5 @@
 import { TabTitle } from 'components/common/Tabs'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import React, { FC, ReactElement, useState } from 'react'
 import { bigNumberToNumber, numberWithCommas } from 'utils/number'
 
@@ -11,7 +11,7 @@ type Props = {
 
 export const AccountGraphTabs: FC<Props> = ({ children, total, isDesktop = false }) => {
   const [selectedTab, setSelectedTab] = useState(0)
-  const { tokenSymbol } = useChains()
+  const { tokenSymbol } = useIndexers()
 
   const tabStyle = isDesktop
     ? 'bg-white border border-slate-100 shadow rounded-[20px] p-4 dark:bg-gradient-to-r dark:from-gradientFrom dark:via-gradientVia dark:to-gradientTo dark:border-none'

--- a/explorer/src/components/Consensus/Account/AccountLatestRewards.tsx
+++ b/explorer/src/components/Consensus/Account/AccountLatestRewards.tsx
@@ -1,6 +1,6 @@
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { AccountByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
 import { FC } from 'react'
@@ -13,7 +13,7 @@ interface AccountLatestRewardsProps {
 }
 
 export const AccountLatestRewards: FC<AccountLatestRewardsProps> = ({ rewards }) => {
-  const { network, section, tokenSymbol } = useChains()
+  const { network, section, tokenSymbol } = useIndexers()
   const { accountId } = useParams<AccountIdParam>()
   const { push } = useRouter()
 

--- a/explorer/src/components/Consensus/Account/AccountList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountList.tsx
@@ -11,7 +11,7 @@ import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { AccountsQuery, AccountsQueryVariables, Order_By as OrderBy } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -144,7 +144,7 @@ export const AccountList: FC = () => {
     [pagination.pageSize, pagination.pageIndex, orderBy, where],
   )
 
-  const { loading, setIsVisible } = useSquidQuery<AccountsQuery, AccountsQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<AccountsQuery, AccountsQueryVariables>(
     QUERY_ACCOUNTS,
     {
       variables,

--- a/explorer/src/components/Consensus/Account/AccountList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountList.tsx
@@ -10,7 +10,7 @@ import { NotFound } from 'components/layout/NotFound'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { AccountsQuery, AccountsQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -30,7 +30,7 @@ const TABLE = 'accounts'
 
 export const AccountList: FC = () => {
   const { ref, inView } = useInView()
-  const { network, section, tokenDecimals } = useChains()
+  const { network, section, tokenDecimals } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Account/AccountRewardGraph.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardGraph.tsx
@@ -4,7 +4,7 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import utc from 'dayjs/plugin/utc'
 import { LatestRewardsWeekQuery, LatestRewardsWeekQueryVariables } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useTheme } from 'providers/ThemeProvider'
 import { FC, useEffect, useMemo } from 'react'
@@ -28,13 +28,13 @@ export const AccountRewardGraph: FC<Props> = ({ accountId, total }) => {
   const lastWeek = dayjs().subtract(3, 'month').utc().format()
   const inFocus = useWindowFocus()
 
-  const { setIsVisible } = useSquidQuery<LatestRewardsWeekQuery, LatestRewardsWeekQueryVariables>(
-    QUERY_LAST_WEEK_REWARDS,
-    {
-      variables: { accountId: accountId, timestampComparison: { _gte: lastWeek } },
-      skip: !inFocus,
-    },
-  )
+  const { setIsVisible } = useIndexersQuery<
+    LatestRewardsWeekQuery,
+    LatestRewardsWeekQueryVariables
+  >(QUERY_LAST_WEEK_REWARDS, {
+    variables: { accountId: accountId, timestampComparison: { _gte: lastWeek } },
+    skip: !inFocus,
+  })
 
   const {
     consensus: { accountRewardGraph: consensusEntry },

--- a/explorer/src/components/Consensus/Account/AccountRewardGraph.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardGraph.tsx
@@ -3,7 +3,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import utc from 'dayjs/plugin/utc'
 import { LatestRewardsWeekQuery, LatestRewardsWeekQueryVariables } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useTheme } from 'providers/ThemeProvider'
@@ -24,7 +24,7 @@ type Props = {
 export const AccountRewardGraph: FC<Props> = ({ accountId, total }) => {
   const { ref, inView } = useInView()
   const { isDark } = useTheme()
-  const { tokenSymbol } = useChains()
+  const { tokenSymbol } = useIndexers()
   const lastWeek = dayjs().subtract(3, 'month').utc().format()
   const inFocus = useWindowFocus()
 

--- a/explorer/src/components/Consensus/Account/AccountRewardList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardList.tsx
@@ -15,8 +15,8 @@ import {
   RewardsListQueryVariables,
 } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useMediaQuery from 'hooks/useMediaQuery'
-import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
@@ -62,7 +62,7 @@ export const AccountRewardList: FC = () => {
     [pagination.pageSize, pagination.pageIndex, sortBy, accountId],
   )
 
-  const { loading, setIsVisible } = useSquidQuery<RewardsListQuery, RewardsListQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<RewardsListQuery, RewardsListQueryVariables>(
     QUERY_REWARDS_LIST,
     {
       variables,

--- a/explorer/src/components/Consensus/Account/AccountRewardList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardList.tsx
@@ -14,7 +14,7 @@ import {
   RewardsListQuery,
   RewardsListQueryVariables,
 } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
@@ -38,7 +38,7 @@ type Row = RewardsListQuery['consensus_rewards'][number]
 
 export const AccountRewardList: FC = () => {
   const { ref, inView } = useInView()
-  const { network, section, tokenSymbol } = useChains()
+  const { network, section, tokenSymbol } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'block_height', desc: true }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
@@ -18,7 +18,7 @@ import {
   Consensus_Transfers_Bool_Exp as TransferWhere,
 } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -75,7 +75,7 @@ export const AccountTransfersList: FC<Props> = ({ accountId }) => {
     }
   }, [orderBy, pagination.pageIndex, pagination.pageSize, where])
 
-  const { data, loading, setIsVisible } = useSquidQuery<
+  const { data, loading, setIsVisible } = useIndexersQuery<
     TransfersByAccountIdQuery,
     TransfersByAccountIdQueryVariables
   >(QUERY_ACCOUNT_TRANSFERS, {

--- a/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
@@ -17,7 +17,7 @@ import {
   TransfersByAccountIdQueryVariables,
   Consensus_Transfers_Bool_Exp as TransferWhere,
 } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -45,7 +45,7 @@ export const AccountTransfersList: FC<Props> = ({ accountId }) => {
     pageSize: PAGE_SIZE,
     pageIndex: 0,
   })
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
   const apolloClient = useApolloClient()
   const inFocus = useWindowFocus()
 

--- a/explorer/src/components/Consensus/Account/BalanceHistory.tsx
+++ b/explorer/src/components/Consensus/Account/BalanceHistory.tsx
@@ -15,7 +15,7 @@ import {
   Consensus_Transfers_Select_Column as TransferColumn,
   Consensus_Transfers_Bool_Exp as TransferWhere,
 } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -42,7 +42,7 @@ export const BalanceHistory: FC<Props> = ({ accountId }) => {
     pageSize: PAGE_SIZE,
     pageIndex: 0,
   })
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
   const apolloClient = useApolloClient()
   const inFocus = useWindowFocus()
 

--- a/explorer/src/components/Consensus/Account/BalanceHistory.tsx
+++ b/explorer/src/components/Consensus/Account/BalanceHistory.tsx
@@ -16,7 +16,7 @@ import {
   Consensus_Transfers_Bool_Exp as TransferWhere,
 } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -67,7 +67,7 @@ export const BalanceHistory: FC<Props> = ({ accountId }) => {
     }
   }, [orderBy, pagination.pageIndex, pagination.pageSize, where])
 
-  const { data, loading, setIsVisible } = useSquidQuery<
+  const { data, loading, setIsVisible } = useIndexersQuery<
     BalanceHistoryByAccountIdQuery,
     BalanceHistoryByAccountIdQueryVariables
   >(QUERY_ACCOUNT_BALANCE_HISTORY, {

--- a/explorer/src/components/Consensus/Block/Block.tsx
+++ b/explorer/src/components/Consensus/Block/Block.tsx
@@ -4,8 +4,8 @@ import { Spinner } from 'components/common/Spinner'
 import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import { BlockByIdQuery, BlockByIdQueryVariables } from 'gql/graphql'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useMediaQuery from 'hooks/useMediaQuery'
-import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useParams } from 'next/navigation'
 import { FC, useEffect, useMemo } from 'react'
@@ -22,7 +22,7 @@ export const Block: FC = () => {
   const isDesktop = useMediaQuery('(min-width: 640px)')
   const inFocus = useWindowFocus()
 
-  const { loading, setIsVisible } = useSquidQuery<BlockByIdQuery, BlockByIdQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<BlockByIdQuery, BlockByIdQueryVariables>(
     QUERY_BLOCK_BY_ID,
     {
       variables: { blockId: blockId ?? '0', blockHash: blockId?.toString() ?? '' },

--- a/explorer/src/components/Consensus/Block/BlockDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsCard.tsx
@@ -3,7 +3,7 @@ import { AccountIconWithLink } from 'components/common/AccountIcon'
 import { CopyButton } from 'components/common/CopyButton'
 import { List, StyledListItem } from 'components/common/List'
 import { BlockByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { FC } from 'react'
 import { utcToLocalRelativeTime, utcToLocalTime } from 'utils/time'
 
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export const BlockDetailsCard: FC<Props> = ({ block, isDesktop = false }) => {
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   return (
     <div className='w-full'>

--- a/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
@@ -7,7 +7,7 @@ import { Spinner } from 'components/common/Spinner'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { EventsByBlockIdQuery, EventsByBlockIdQueryVariables } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -26,7 +26,7 @@ type Row = EventsByBlockIdQuery['consensus_events'][number]
 export const BlockDetailsEventList: FC = () => {
   const { ref, inView } = useInView()
   const { blockId } = useParams()
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const apolloClient = useApolloClient()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
   const [pagination, setPagination] = useState({

--- a/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
@@ -8,7 +8,7 @@ import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { EventsByBlockIdQuery, EventsByBlockIdQueryVariables } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
@@ -47,7 +47,7 @@ export const BlockDetailsEventList: FC = () => {
     [pagination.pageSize, pagination.pageIndex, orderBy, blockId],
   )
 
-  const { data, loading, setIsVisible } = useSquidQuery<
+  const { data, loading, setIsVisible } = useIndexersQuery<
     EventsByBlockIdQuery,
     EventsByBlockIdQueryVariables
   >(QUERY_BLOCK_EVENTS, {

--- a/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
@@ -8,7 +8,7 @@ import { StatusIcon } from 'components/common/StatusIcon'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { ExtrinsicsByBlockIdQuery, ExtrinsicsByBlockIdQueryVariables } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -30,7 +30,7 @@ type Row = ExtrinsicsByBlockIdQuery['consensus_extrinsics'][number]
 export const BlockDetailsExtrinsicList: FC<Props> = ({ isDesktop = false }) => {
   const { ref, inView } = useInView()
   const { blockId } = useParams()
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
@@ -9,7 +9,7 @@ import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { ExtrinsicsByBlockIdQuery, ExtrinsicsByBlockIdQueryVariables } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
@@ -39,7 +39,7 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({ isDesktop = false }) => {
   const inFocus = useWindowFocus()
 
   const limit = useMemo(() => (isDesktop ? 10 : 5), [isDesktop])
-  const { data, loading, setIsVisible } = useSquidQuery<
+  const { data, loading, setIsVisible } = useIndexersQuery<
     ExtrinsicsByBlockIdQuery,
     ExtrinsicsByBlockIdQueryVariables
   >(QUERY_BLOCK_EXTRINSICS, {

--- a/explorer/src/components/Consensus/Block/BlockDetailsLogList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsLogList.tsx
@@ -5,7 +5,7 @@ import { SortedTable } from 'components/common/SortedTable'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { BlockByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC, useMemo, useState } from 'react'
 import type { Cell } from 'types/table'
@@ -18,7 +18,7 @@ type Props = {
 }
 
 export const BlockDetailsLogList: FC<Props> = ({ logs }) => {
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Block/BlockList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockList.tsx
@@ -12,7 +12,7 @@ import { NotFound } from 'components/layout/NotFound'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { BlocksQuery, BlocksQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -31,7 +31,7 @@ const TABLE = 'blocks'
 export const BlockList: FC = () => {
   const { ref, inView } = useInView()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'sort_id', desc: true }])
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Block/BlockList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockList.tsx
@@ -13,7 +13,7 @@ import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { BlocksQuery, BlocksQueryVariables, Order_By as OrderBy } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -125,7 +125,7 @@ export const BlockList: FC = () => {
     [pagination.pageSize, pagination.pageIndex, orderBy, where],
   )
 
-  const { loading, setIsVisible } = useSquidQuery<BlocksQuery, BlocksQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<BlocksQuery, BlocksQueryVariables>(
     QUERY_BLOCKS,
     {
       variables,

--- a/explorer/src/components/Consensus/Event/Event.tsx
+++ b/explorer/src/components/Consensus/Event/Event.tsx
@@ -4,7 +4,7 @@ import { Spinner } from 'components/common/Spinner'
 import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import type { EventByIdQuery, EventByIdQueryVariables } from 'gql/graphql'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useParams } from 'next/navigation'
 import { FC, useEffect, useMemo } from 'react'
@@ -18,7 +18,7 @@ export const Event: FC = () => {
   const { ref, inView } = useInView()
   const { eventId } = useParams<EventIdParam>()
   const inFocus = useWindowFocus()
-  const { loading, setIsVisible } = useSquidQuery<EventByIdQuery, EventByIdQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<EventByIdQuery, EventByIdQueryVariables>(
     QUERY_EVENT_BY_ID,
     {
       variables: { eventId: eventId ?? '' },

--- a/explorer/src/components/Consensus/Event/EventDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Event/EventDetailsCard.tsx
@@ -3,7 +3,7 @@ import { List, StyledListItem } from 'components/common/List'
 import { NotFound } from 'components/layout/NotFound'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { EventByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC } from 'react'
 import { parseArgs } from 'utils/indexerParsing'
@@ -14,7 +14,7 @@ type Props = {
 }
 
 export const EventDetailsCard: FC<Props> = ({ event }) => {
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   if (!event) return <NotFound />
   return (

--- a/explorer/src/components/Consensus/Event/EventList.tsx
+++ b/explorer/src/components/Consensus/Event/EventList.tsx
@@ -9,7 +9,7 @@ import { TableSettings } from 'components/common/TableSettings'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { EventsQuery, EventsQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -28,7 +28,7 @@ const TABLE = 'events'
 
 export const EventList: FC = () => {
   const { ref, inView } = useInView()
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'sort_id', desc: true }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Event/EventList.tsx
+++ b/explorer/src/components/Consensus/Event/EventList.tsx
@@ -10,7 +10,7 @@ import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { EventsQuery, EventsQueryVariables, Order_By as OrderBy } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -102,7 +102,7 @@ export const EventList: FC = () => {
     [pagination.pageSize, pagination.pageIndex, orderBy, where],
   )
 
-  const { loading, setIsVisible } = useSquidQuery<EventsQuery, EventsQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<EventsQuery, EventsQueryVariables>(
     QUERY_EVENTS,
     {
       variables,

--- a/explorer/src/components/Consensus/Extrinsic/Extrinsic.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/Extrinsic.tsx
@@ -4,8 +4,8 @@ import { Spinner } from 'components/common/Spinner'
 import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import { ExtrinsicsByIdQuery, ExtrinsicsByIdQueryVariables } from 'gql/graphql'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useMediaQuery from 'hooks/useMediaQuery'
-import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useParams } from 'next/navigation'
 import { FC, useEffect, useMemo } from 'react'
@@ -23,7 +23,7 @@ export const Extrinsic: FC = () => {
   const isDesktop = useMediaQuery('(min-width: 1440px)')
   const isLargeDesktop = useMediaQuery('(min-width: 1440px)')
 
-  const { loading, setIsVisible } = useSquidQuery<
+  const { loading, setIsVisible } = useIndexersQuery<
     ExtrinsicsByIdQuery,
     ExtrinsicsByIdQueryVariables
   >(

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsCard.tsx
@@ -5,7 +5,7 @@ import { List, StyledListItem } from 'components/common/List'
 import { StatusIcon } from 'components/common/StatusIcon'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { ExtrinsicsByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC } from 'react'
 import { parseArgs } from 'utils/indexerParsing'
@@ -17,7 +17,7 @@ type Props = {
 }
 
 export const ExtrinsicDetailsCard: FC<Props> = ({ extrinsic, isDesktop = false }) => {
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   const [module, call] = extrinsic.name.split('.')
 

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsEventList.tsx
@@ -5,7 +5,7 @@ import { SortedTable } from 'components/common/SortedTable'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { ExtrinsicsByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC, useMemo, useState } from 'react'
 import type { Cell } from 'types/table'
@@ -18,7 +18,7 @@ type Props = {
 type Row = NonNullable<ExtrinsicsByIdQuery['consensus_extrinsics'][number]>['events'][number]
 
 export const ExtrinsicDetailsEventList: FC<Props> = ({ events }) => {
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx
@@ -12,7 +12,7 @@ import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { ExtrinsicsQuery, ExtrinsicsQueryVariables, Order_By as OrderBy } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
@@ -102,7 +102,7 @@ export const ExtrinsicList: FC = () => {
     [pagination.pageSize, pagination.pageIndex, where, orderBy],
   )
 
-  const { loading, setIsVisible } = useSquidQuery<ExtrinsicsQuery, ExtrinsicsQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<ExtrinsicsQuery, ExtrinsicsQueryVariables>(
     QUERY_EXTRINSICS,
     {
       variables,

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx
@@ -11,7 +11,7 @@ import { TableSettings } from 'components/common/TableSettings'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { ExtrinsicsQuery, ExtrinsicsQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -29,7 +29,7 @@ const TABLE = 'extrinsics'
 
 export const ExtrinsicList: FC = () => {
   const { ref, inView } = useInView()
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'sort_id', desc: true }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Home/HomeBlockList.tsx
+++ b/explorer/src/components/Consensus/Home/HomeBlockList.tsx
@@ -4,7 +4,7 @@ import { ArrowLongRightIcon } from '@heroicons/react/24/outline'
 import { SortedTable } from 'components/common/SortedTable'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { HomeQueryQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
 import type { Cell } from 'types/table'
@@ -17,7 +17,7 @@ interface HomeBlockListProps {
 type Row = HomeQueryQuery['consensus_blocks'][number]
 
 export const HomeBlockList: FC<HomeBlockListProps> = ({ data }) => {
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   const blocks = useMemo(() => data.consensus_blocks, [data.consensus_blocks])
 

--- a/explorer/src/components/Consensus/Home/HomeExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Home/HomeExtrinsicList.tsx
@@ -6,7 +6,7 @@ import { SortedTable } from 'components/common/SortedTable'
 import { StatusIcon } from 'components/common/StatusIcon'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { HomeQueryQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
 import type { Cell } from 'types/table'
@@ -19,7 +19,7 @@ interface HomeExtrinsicListProps {
 type Row = HomeQueryQuery['consensus_extrinsics'][number]
 
 export const HomeExtrinsicList: FC<HomeExtrinsicListProps> = ({ data }) => {
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   const extrinsics = useMemo(() => data.consensus_extrinsics, [data.consensus_extrinsics])
 

--- a/explorer/src/components/Consensus/Home/index.tsx
+++ b/explorer/src/components/Consensus/Home/index.tsx
@@ -4,8 +4,8 @@ import { SearchBar } from 'components/common/SearchBar'
 import { Spinner } from 'components/common/Spinner'
 import { Routes } from 'constants/routes'
 import type { HomeQueryQuery, HomeQueryQueryVariables } from 'gql/graphql'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useMediaQuery from 'hooks/useMediaQuery'
-import { useSquidQuery } from 'hooks/useSquidQuery'
 import { FC, useEffect, useMemo } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { hasValue, isLoading, useQueryStates } from 'states/query'
@@ -20,7 +20,7 @@ export const Home: FC = () => {
   const isDesktop = useMediaQuery('(min-width: 640px)')
   const PAGE_SIZE = useMemo(() => (isDesktop ? 10 : 3), [isDesktop])
 
-  const { loading, setIsVisible } = useSquidQuery<HomeQueryQuery, HomeQueryQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<HomeQueryQuery, HomeQueryQueryVariables>(
     QUERY_HOME,
     {
       variables: { limit: PAGE_SIZE, offset: 0 },

--- a/explorer/src/components/Consensus/Log/Log.tsx
+++ b/explorer/src/components/Consensus/Log/Log.tsx
@@ -4,7 +4,7 @@ import { Spinner } from 'components/common/Spinner'
 import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import type { LogByIdQuery, LogByIdQueryVariables } from 'gql/graphql'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useParams } from 'next/navigation'
 import { FC, useEffect, useMemo } from 'react'
@@ -19,7 +19,7 @@ export const Log: FC = () => {
   const { ref, inView } = useInView()
   const { logId } = useParams<LogIdParam>()
   const inFocus = useWindowFocus()
-  const { loading, setIsVisible } = useSquidQuery<LogByIdQuery, LogByIdQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<LogByIdQuery, LogByIdQueryVariables>(
     QUERY_LOG_BY_ID,
     {
       variables: { logId: logId ?? '' },

--- a/explorer/src/components/Consensus/Log/LogDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Log/LogDetailsEventList.tsx
@@ -5,7 +5,7 @@ import { SortedTable } from 'components/common/SortedTable'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { LogByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC, useMemo, useState } from 'react'
 import type { Cell } from 'types/table'
@@ -20,7 +20,7 @@ type Row = NonNullable<
 >['events'][number]
 
 export const LogDetailsEventList: FC<Props> = ({ events }) => {
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Log/LogList.tsx
+++ b/explorer/src/components/Consensus/Log/LogList.tsx
@@ -9,7 +9,7 @@ import { TableSettings } from 'components/common/TableSettings'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { LogsQuery, LogsQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -28,7 +28,7 @@ const TABLE = 'logs'
 
 export const LogList: FC = () => {
   const { ref, inView } = useInView()
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Consensus/Log/LogList.tsx
+++ b/explorer/src/components/Consensus/Log/LogList.tsx
@@ -10,7 +10,7 @@ import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { LogsQuery, LogsQueryVariables, Order_By as OrderBy } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -97,7 +97,7 @@ export const LogList: FC = () => {
     [pagination.pageSize, pagination.pageIndex, orderBy, where],
   )
 
-  const { loading, setIsVisible } = useSquidQuery<LogsQuery, LogsQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<LogsQuery, LogsQueryVariables>(
     QUERY_LOGS,
     {
       variables,

--- a/explorer/src/components/Domain/Domain.tsx
+++ b/explorer/src/components/Domain/Domain.tsx
@@ -4,7 +4,7 @@ import { Spinner } from 'components/common/Spinner'
 import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import type { DomainByIdQuery, DomainByIdQueryVariables } from 'gql/graphql'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useParams, useRouter } from 'next/navigation'
 import { FC, useEffect, useMemo } from 'react'
@@ -22,7 +22,7 @@ export const Domain: FC = () => {
 
   // eslint
   const variables = useMemo(() => ({ domainId: domainId ?? '' }), [domainId])
-  const { setIsVisible } = useSquidQuery<DomainByIdQuery, DomainByIdQueryVariables>(
+  const { setIsVisible } = useIndexersQuery<DomainByIdQuery, DomainByIdQueryVariables>(
     QUERY_DOMAIN_BY_ID,
     {
       variables,

--- a/explorer/src/components/Domain/DomainBlockTime.tsx
+++ b/explorer/src/components/Domain/DomainBlockTime.tsx
@@ -2,7 +2,7 @@ import { capitalizeFirstLetter } from '@autonomys/auto-utils'
 import { Spinner } from 'components/common/Spinner'
 import { NotFound } from 'components/layout/NotFound'
 import { DomainsStatusQuery, DomainsStatusQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { FC, useMemo } from 'react'
 import { useInView } from 'react-intersection-observer'
@@ -141,19 +141,19 @@ export const DomainBlockTime: FC = () => {
   const { ref } = useInView()
   const inFocus = useWindowFocus()
 
-  const { data, loading, error } = useSquidQuery<DomainsStatusQuery, DomainsStatusQueryVariables>(
-    QUERY_DOMAIN_STATUS,
-    {
-      variables: {
-        limit: 10,
-        orderBy: [{ id: OrderBy.Asc }],
-        where: {},
-      },
-      skip: !inFocus,
-      pollInterval: 2000,
-      context: { clientName: 'staking' },
+  const { data, loading, error } = useIndexersQuery<
+    DomainsStatusQuery,
+    DomainsStatusQueryVariables
+  >(QUERY_DOMAIN_STATUS, {
+    variables: {
+      limit: 10,
+      orderBy: [{ id: OrderBy.Asc }],
+      where: {},
     },
-  )
+    skip: !inFocus,
+    pollInterval: 2000,
+    context: { clientName: 'staking' },
+  })
 
   const cards = useMemo(() => {
     if (loading || error || !data) return []

--- a/explorer/src/components/Domain/DomainCards.tsx
+++ b/explorer/src/components/Domain/DomainCards.tsx
@@ -4,7 +4,7 @@ import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import { DomainsStatusQuery, DomainsStatusQueryVariables, Order_By as OrderBy } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useEffect, useMemo } from 'react'
@@ -27,7 +27,7 @@ export const DomainCards: FC = () => {
   const { network } = useIndexers()
   const inFocus = useWindowFocus()
 
-  const { data, loading, error, setIsVisible } = useSquidQuery<
+  const { data, loading, error, setIsVisible } = useIndexersQuery<
     DomainsStatusQuery,
     DomainsStatusQueryVariables
   >(QUERY_DOMAIN_STATUS, {

--- a/explorer/src/components/Domain/DomainCards.tsx
+++ b/explorer/src/components/Domain/DomainCards.tsx
@@ -3,7 +3,7 @@ import { BlockIcon, DocIcon } from 'components/icons'
 import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import { DomainsStatusQuery, DomainsStatusQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -24,7 +24,7 @@ interface CardData {
 
 export const DomainCards: FC = () => {
   const { ref, inView } = useInView()
-  const { network } = useChains()
+  const { network } = useIndexers()
   const inFocus = useWindowFocus()
 
   const { data, loading, error, setIsVisible } = useSquidQuery<

--- a/explorer/src/components/Domain/DomainDetailsCard.tsx
+++ b/explorer/src/components/Domain/DomainDetailsCard.tsx
@@ -3,7 +3,7 @@ import { CopyButton } from 'components/common/CopyButton'
 import { List, StyledListItem } from 'components/common/List'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import type { DomainByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC } from 'react'
 import { bigNumberToFormattedString } from 'utils/number'
@@ -14,7 +14,7 @@ type Props = {
 }
 
 export const DomainDetailsCard: FC<Props> = ({ domain }) => {
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
 
   if (!domain) return null
 

--- a/explorer/src/components/Domain/DomainProgress.tsx
+++ b/explorer/src/components/Domain/DomainProgress.tsx
@@ -4,7 +4,7 @@ import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import { DomainsStatusQuery, DomainsStatusQueryVariables, Order_By as OrderBy } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { FC, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
@@ -44,19 +44,19 @@ export const DomainProgress: FC = () => {
   const { network } = useIndexers()
   const inFocus = useWindowFocus()
 
-  const { data, loading, error } = useSquidQuery<DomainsStatusQuery, DomainsStatusQueryVariables>(
-    QUERY_DOMAIN_STATUS,
-    {
-      variables: {
-        limit: 10,
-        orderBy: [{ id: OrderBy.Asc }],
-        where: {},
-      },
-      skip: !inFocus,
-      pollInterval: 2000,
-      context: { clientName: 'staking' },
+  const { data, loading, error } = useIndexersQuery<
+    DomainsStatusQuery,
+    DomainsStatusQueryVariables
+  >(QUERY_DOMAIN_STATUS, {
+    variables: {
+      limit: 10,
+      orderBy: [{ id: OrderBy.Asc }],
+      where: {},
     },
-  )
+    skip: !inFocus,
+    pollInterval: 2000,
+    context: { clientName: 'staking' },
+  })
 
   const cards = useMemo<CardData[]>(() => {
     if (loading || error || !data) return []

--- a/explorer/src/components/Domain/DomainProgress.tsx
+++ b/explorer/src/components/Domain/DomainProgress.tsx
@@ -3,7 +3,7 @@ import { Spinner } from 'components/common/Spinner'
 import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import { DomainsStatusQuery, DomainsStatusQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { FC, useEffect, useMemo, useState } from 'react'
@@ -41,7 +41,7 @@ const CountdownTimer: FC<{ initialTime: bigint }> = ({ initialTime }) => {
 
 export const DomainProgress: FC = () => {
   const { ref } = useInView()
-  const { network } = useChains()
+  const { network } = useIndexers()
   const inFocus = useWindowFocus()
 
   const { data, loading, error } = useSquidQuery<DomainsStatusQuery, DomainsStatusQueryVariables>(

--- a/explorer/src/components/Domain/DomainsList.tsx
+++ b/explorer/src/components/Domain/DomainsList.tsx
@@ -11,7 +11,7 @@ import { DomainsListQuery, DomainsListQueryVariables, Order_By as OrderBy } from
 import { useConsensusData } from 'hooks/useConsensusData'
 import { useDomainsData } from 'hooks/useDomainsData'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -366,7 +366,7 @@ export const DomainsList: FC = () => {
     [pagination.pageSize, pagination.pageIndex, orderBy, where],
   )
 
-  const { loading, setIsVisible } = useSquidQuery<DomainsListQuery, DomainsListQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<DomainsListQuery, DomainsListQueryVariables>(
     QUERY_DOMAIN_LIST,
     {
       variables,

--- a/explorer/src/components/Domain/DomainsList.tsx
+++ b/explorer/src/components/Domain/DomainsList.tsx
@@ -8,9 +8,9 @@ import { Spinner } from 'components/common/Spinner'
 import { PAGE_SIZE } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { DomainsListQuery, DomainsListQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import useChains from 'hooks/useChains'
 import { useConsensusData } from 'hooks/useConsensusData'
 import { useDomainsData } from 'hooks/useDomainsData'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -44,7 +44,7 @@ export const DomainsList: FC = () => {
   })
   useDomainsData()
   useConsensusData()
-  const { network, section, tokenSymbol, tokenDecimals } = useChains()
+  const { network, section, tokenSymbol, tokenDecimals } = useIndexers()
   const apolloClient = useApolloClient()
   const inFocus = useWindowFocus()
   const availableColumns = useTableStates((state) => state[TABLE].columns)

--- a/explorer/src/components/Leaderboard/LeaderboardList.tsx
+++ b/explorer/src/components/Leaderboard/LeaderboardList.tsx
@@ -12,7 +12,7 @@ import {
   Order_By as OrderBy,
 } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -207,7 +207,7 @@ export const LeaderboardList: FC<LeaderboardListProps> = ({
     loading,
     data: listData,
     setIsVisible,
-  } = useSquidQuery<
+  } = useIndexersQuery<
     AccountTransferSenderTotalCountQuery,
     AccountTransferSenderTotalCountQueryVariables
   >(query, {

--- a/explorer/src/components/Leaderboard/LeaderboardList.tsx
+++ b/explorer/src/components/Leaderboard/LeaderboardList.tsx
@@ -11,7 +11,7 @@ import {
   AccountTransferSenderTotalCountQueryVariables,
   Order_By as OrderBy,
 } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
@@ -63,7 +63,7 @@ export const LeaderboardList: FC<LeaderboardListProps> = ({
     pageIndex: 0,
   })
   const apolloClient = useApolloClient()
-  const { network, tokenDecimals } = useChains()
+  const { network, tokenDecimals } = useIndexers()
   const inFocus = useWindowFocus()
   const availableColumns = useTableStates((state) => state[TABLE].columns)
   const selectedColumns = useTableStates((state) => state[TABLE].selectedColumns)

--- a/explorer/src/components/Leaderboard/index.tsx
+++ b/explorer/src/components/Leaderboard/index.tsx
@@ -4,7 +4,7 @@ import { capitalizeFirstLetter } from '@autonomys/auto-utils'
 import { PageTabs } from 'components/common/PageTabs'
 import { Tab } from 'components/common/Tabs'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import useWallet from 'hooks/useWallet'
 import React, { FC, useCallback } from 'react'
@@ -85,7 +85,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ children }) => {
 
 export const AccountLeaderboard: FC = () => {
   const isDesktop = useMediaQuery('(min-width: 640px)')
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
 
   return (
     <Leaderboard>
@@ -181,7 +181,7 @@ export const AccountLeaderboard: FC = () => {
 
 export const FarmerLeaderboard: FC = () => {
   const isDesktop = useMediaQuery('(min-width: 640px)')
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
 
   return (
     <Leaderboard>
@@ -256,7 +256,7 @@ export const FarmerLeaderboard: FC = () => {
 
 export const OperatorLeaderboard: FC = () => {
   const isDesktop = useMediaQuery('(min-width: 640px)')
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
 
   return (
     <Leaderboard>
@@ -334,7 +334,7 @@ export const OperatorLeaderboard: FC = () => {
 
 export const NominatorLeaderboard: FC = () => {
   const isDesktop = useMediaQuery('(min-width: 640px)')
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
 
   return (
     <Leaderboard>

--- a/explorer/src/components/Staking/MyWithdrawals.tsx
+++ b/explorer/src/components/Staking/MyWithdrawals.tsx
@@ -1,6 +1,6 @@
 import { BIGINT_ZERO, SHARES_CALCULATION_MULTIPLIER } from 'constants/general'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
@@ -40,7 +40,7 @@ type MyUnlockedWithdrawal = {
 
 export const MyUnlockedWithdrawals: FC<MyUnlockedWithdrawalsProps> = ({ action, handleAction }) => {
   const { subspaceAccount } = useWallet()
-  const { section, network, tokenSymbol } = useChains()
+  const { section, network, tokenSymbol } = useIndexers()
   const { withdrawals } = useConsensusStates()
 
   const myUnlockedWithdrawals = useMemo(() => {
@@ -182,7 +182,7 @@ export const MyUnlockedWithdrawals: FC<MyUnlockedWithdrawalsProps> = ({ action, 
 
 export const MyPendingWithdrawals: FC = () => {
   const { subspaceAccount } = useWallet()
-  const { section, network, tokenSymbol } = useChains()
+  const { section, network, tokenSymbol } = useIndexers()
   const { operators, withdrawals } = useConsensusStates()
 
   const myPendingWithdrawals = useMemo(

--- a/explorer/src/components/Staking/NominationsTable.tsx
+++ b/explorer/src/components/Staking/NominationsTable.tsx
@@ -14,7 +14,7 @@ import {
   NominationsListQueryVariables,
   Order_By as OrderBy,
 } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
@@ -35,7 +35,7 @@ export const NominationsTable: FC = () => {
   const { ref, inView } = useInView()
   const { subspaceAccount } = useWallet()
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
   const [sorting] = useState<SortingState>([{ id: 'operator_id', desc: false }])
   const { myPositionOnly } = useViewStates()
 

--- a/explorer/src/components/Staking/NominationsTable.tsx
+++ b/explorer/src/components/Staking/NominationsTable.tsx
@@ -15,7 +15,7 @@ import {
   Order_By as OrderBy,
 } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -75,7 +75,7 @@ export const NominationsTable: FC = () => {
     [myPositionOnly, orderBy, subspaceAccount],
   )
 
-  const { loading, data, setIsVisible } = useSquidQuery<
+  const { loading, data, setIsVisible } = useIndexersQuery<
     NominationsListQuery,
     NominationsListQueryVariables
   >(QUERY_NOMINATIONS_LIST, {

--- a/explorer/src/components/Staking/Operator.tsx
+++ b/explorer/src/components/Staking/Operator.tsx
@@ -5,8 +5,8 @@ import { NotFound } from 'components/layout/NotFound'
 import { Routes } from 'constants/routes'
 import type { OperatorByIdQuery, OperatorByIdQueryVariables } from 'gql/graphql'
 import { useConsensusData } from 'hooks/useConsensusData'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useMediaQuery from 'hooks/useMediaQuery'
-import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useParams, useRouter } from 'next/navigation'
 import { FC, useEffect, useMemo } from 'react'
@@ -25,7 +25,7 @@ export const Operator: FC = () => {
   const { loadDataByOperatorId } = useConsensusData()
 
   const variables = useMemo(() => ({ operatorId: operatorId ?? '' }), [operatorId])
-  const { loading, setIsVisible } = useSquidQuery<OperatorByIdQuery, OperatorByIdQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<OperatorByIdQuery, OperatorByIdQueryVariables>(
     QUERY_OPERATOR_BY_ID,
     {
       variables,

--- a/explorer/src/components/Staking/OperatorDetailsCard.tsx
+++ b/explorer/src/components/Staking/OperatorDetailsCard.tsx
@@ -3,7 +3,7 @@ import { CopyButton } from 'components/common/CopyButton'
 import { List, StyledListItem } from 'components/common/List'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import type { OperatorByIdQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC } from 'react'
 import { bigNumberToFormattedString } from 'utils/number'
@@ -16,7 +16,7 @@ type Props = {
 }
 
 export const OperatorDetailsCard: FC<Props> = ({ operator, isDesktop = false }) => {
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
 
   if (!operator) return null
 

--- a/explorer/src/components/Staking/OperatorNominatorTable.tsx
+++ b/explorer/src/components/Staking/OperatorNominatorTable.tsx
@@ -8,7 +8,7 @@ import {
   OperatorNominatorsByIdQueryVariables,
   Order_By as OrderBy,
 } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
@@ -36,7 +36,7 @@ export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
   const { subspaceAccount } = useWallet()
   const { operatorId } = useParams<{ operatorId?: string }>()
   const inFocus = useWindowFocus()
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,

--- a/explorer/src/components/Staking/OperatorNominatorTable.tsx
+++ b/explorer/src/components/Staking/OperatorNominatorTable.tsx
@@ -9,7 +9,7 @@ import {
   Order_By as OrderBy,
 } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useParams } from 'next/navigation'
@@ -174,7 +174,7 @@ export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
     [pagination.pageSize, pagination.pageIndex, orderBy, operatorId],
   )
 
-  const { loading, setIsVisible } = useSquidQuery<
+  const { loading, setIsVisible } = useIndexersQuery<
     OperatorNominatorsByIdQuery,
     OperatorNominatorsByIdQueryVariables
   >(

--- a/explorer/src/components/Staking/OperatorsList.tsx
+++ b/explorer/src/components/Staking/OperatorsList.tsx
@@ -13,7 +13,7 @@ import { OperatorsListQuery, OperatorsListQueryVariables, Order_By as OrderBy } 
 import { useConsensusData } from 'hooks/useConsensusData'
 import { useDomainsData } from 'hooks/useDomainsData'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -528,7 +528,10 @@ export const OperatorsList: FC<OperatorsListProps> = ({ domainId }) => {
     [pagination, orderBy, where],
   )
 
-  const { loading, setIsVisible } = useSquidQuery<OperatorsListQuery, OperatorsListQueryVariables>(
+  const { loading, setIsVisible } = useIndexersQuery<
+    OperatorsListQuery,
+    OperatorsListQueryVariables
+  >(
     QUERY_OPERATOR_LIST,
     {
       variables,

--- a/explorer/src/components/Staking/OperatorsList.tsx
+++ b/explorer/src/components/Staking/OperatorsList.tsx
@@ -10,9 +10,9 @@ import { BIGINT_ZERO, PAGE_SIZE, SHARES_CALCULATION_MULTIPLIER } from 'constants
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { OperatorPendingAction, OperatorStatus } from 'constants/staking'
 import { OperatorsListQuery, OperatorsListQueryVariables, Order_By as OrderBy } from 'gql/graphql'
-import useChains from 'hooks/useChains'
 import { useConsensusData } from 'hooks/useConsensusData'
 import { useDomainsData } from 'hooks/useDomainsData'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
@@ -59,7 +59,7 @@ export const OperatorsList: FC<OperatorsListProps> = ({ domainId }) => {
     pageSize: PAGE_SIZE,
     pageIndex: 0,
   })
-  const { network, tokenSymbol, tokenDecimals } = useChains()
+  const { network, tokenSymbol, tokenDecimals } = useIndexers()
   const { subspaceAccount } = useWallet()
   const { operators: rpcOperators, domainRegistry, deposits } = useConsensusStates()
   useConsensusData()

--- a/explorer/src/components/TestnetRewards/RewardHistory.tsx
+++ b/explorer/src/components/TestnetRewards/RewardHistory.tsx
@@ -6,7 +6,7 @@ import { WalletButton } from 'components/WalletButton'
 import AccountListDropdown from 'components/WalletButton/AccountListDropdown'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { WalletType } from 'constants/wallet'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
 import { FC, useCallback, useMemo } from 'react'
@@ -15,7 +15,7 @@ import { formatAddress } from 'utils/formatAddress'
 import { AccountIcon } from '../common/AccountIcon'
 
 export const RewardHistory: FC = () => {
-  const { network } = useChains()
+  const { network } = useIndexers()
   const { actingAccount, subspaceAccount, accounts } = useWallet()
   const { mySubspaceWallets, addSubspaceWallet, removeSubspaceWallet } = useViewStates()
 

--- a/explorer/src/components/WalletSideKick/AccountPreferencesModal.tsx
+++ b/explorer/src/components/WalletSideKick/AccountPreferencesModal.tsx
@@ -3,7 +3,7 @@ import { Modal } from 'components/common/Modal'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { AccountPreferenceSection, WalletType } from 'constants/wallet'
 import { Field, FieldArray, Form, Formik, FormikState } from 'formik'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
 import { FC, useCallback, useMemo, useState } from 'react'
@@ -24,7 +24,7 @@ type AccountSetting = {
 }
 
 export const AccountPreferencesModal: FC<ActionsModalProps> = ({ isOpen, preference, onClose }) => {
-  const { network } = useChains()
+  const { network } = useIndexers()
   const { actingAccount } = useWallet()
   const [formError, setFormError] = useState<string | null>(null)
   const { addresses, addAddress, removeAddress } = useAddressBookStates()

--- a/explorer/src/components/WalletSideKick/AccountSummary.tsx
+++ b/explorer/src/components/WalletSideKick/AccountSummary.tsx
@@ -4,7 +4,7 @@ import { Accordion } from 'components/common/Accordion'
 import { Tooltip } from 'components/common/Tooltip'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import { AccountPreferenceSection } from 'constants/wallet'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
@@ -29,7 +29,7 @@ export const AccountSummary: FC<AccountSummaryProps> = ({
   tokenSymbol,
 }) => {
   const { ref, inView } = useInView()
-  const { network } = useChains()
+  const { network } = useIndexers()
   const { topFarmers, topOperators, topNominators, setIsVisible } = useLeaderboard(subspaceAccount)
   const { enableDevMode } = usePreferencesStates()
   const [preference, setPreference] = useState<AccountPreferenceSection>(

--- a/explorer/src/components/WalletSideKick/Actions/ClaimStakingToken.tsx
+++ b/explorer/src/components/WalletSideKick/Actions/ClaimStakingToken.tsx
@@ -4,7 +4,7 @@ import { StyledButton } from 'components/common/StyledButton'
 import { QUERY_EXTRINSIC_BY_HASH } from 'components/Consensus/Extrinsic/query'
 import { ROUTE_API, ROUTE_EXTRA_FLAG_TYPE } from 'constants/routes'
 import { ExtrinsicsByHashQuery, ExtrinsicsByHashQueryVariables } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
@@ -15,7 +15,7 @@ import { hasValue, useQueryStates } from 'states/query'
 export const ClaimStakingToken: FC = () => {
   const { inView, ref } = useInView()
   const { actingAccount, subspaceAccount, injector } = useWallet()
-  const { network, tokenSymbol } = useChains()
+  const { network, tokenSymbol } = useIndexers()
 
   const [claimIsPending, setClaimIsPending] = useState(false)
   const [claimIsFinalized, setClaimIsFinalized] = useState(false)

--- a/explorer/src/components/WalletSideKick/Actions/ClaimStakingToken.tsx
+++ b/explorer/src/components/WalletSideKick/Actions/ClaimStakingToken.tsx
@@ -5,7 +5,7 @@ import { QUERY_EXTRINSIC_BY_HASH } from 'components/Consensus/Extrinsic/query'
 import { ROUTE_API, ROUTE_EXTRA_FLAG_TYPE } from 'constants/routes'
 import { ExtrinsicsByHashQuery, ExtrinsicsByHashQueryVariables } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { FC, useCallback, useEffect, useState } from 'react'
@@ -23,7 +23,7 @@ export const ClaimStakingToken: FC = () => {
   const [claimHash, setClaimHash] = useState<string | null>(null)
   const inFocus = useWindowFocus()
 
-  const { setIsVisible } = useSquidQuery<ExtrinsicsByHashQuery, ExtrinsicsByHashQueryVariables>(
+  const { setIsVisible } = useIndexersQuery<ExtrinsicsByHashQuery, ExtrinsicsByHashQueryVariables>(
     QUERY_EXTRINSIC_BY_HASH,
     {
       variables: { hash: claimHash ?? '' },

--- a/explorer/src/components/WalletSideKick/ActionsButtons.tsx
+++ b/explorer/src/components/WalletSideKick/ActionsButtons.tsx
@@ -9,7 +9,7 @@ import {
 import { sendGAEvent } from '@next/third-parties/google'
 import { Tooltip } from 'components/common/Tooltip'
 import { WalletAction } from 'constants/wallet'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useWallet from 'hooks/useWallet'
 import { FC, useCallback, useState } from 'react'
 import { ActionsModal } from './ActionsModal'
@@ -20,7 +20,7 @@ interface ActionsButtonsProps {
 
 export const ActionsButtons: FC<ActionsButtonsProps> = ({ tokenSymbol }) => {
   const { subspaceAccount } = useWallet()
-  const { network } = useChains()
+  const { network } = useIndexers()
   const [isOpen, setIsOpen] = useState(false)
   const [action, setAction] = useState<WalletAction>(WalletAction.None)
 

--- a/explorer/src/components/WalletSideKick/ActionsModal.tsx
+++ b/explorer/src/components/WalletSideKick/ActionsModal.tsx
@@ -13,7 +13,7 @@ import {
   WalletType,
 } from 'constants/wallet'
 import { Field, FieldArray, Form, Formik, FormikState } from 'formik'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useTxHelper } from 'hooks/useTxHelper'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
@@ -54,7 +54,7 @@ interface MessageFormValues extends OptionalTxFormValues {
 }
 
 export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose }) => {
-  const { network } = useChains()
+  const { network } = useIndexers()
   const { api, actingAccount, accounts, injector, subspaceAccount } = useWallet()
   const [formError, setFormError] = useState<string | null>(null)
   const [tokenDecimals, setTokenDecimals] = useState<number>(0)

--- a/explorer/src/components/WalletSideKick/LastExtrinsics.tsx
+++ b/explorer/src/components/WalletSideKick/LastExtrinsics.tsx
@@ -12,7 +12,7 @@ import {
   Routes,
 } from 'constants/routes'
 import { ExtrinsicsSummaryQuery, ExtrinsicsSummaryQueryVariables } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -29,7 +29,7 @@ interface LastExtrinsicsProps {
 
 export const LastExtrinsics: FC<LastExtrinsicsProps> = ({ subspaceAccount }) => {
   const { ref, inView } = useInView()
-  const { network } = useChains()
+  const { network } = useIndexers()
   const inFocus = useWindowFocus()
   const { get } = useSearchParams()
   const isSideKickOpen = get(ROUTE_EXTRA_FLAG_TYPE.WALLET_SIDEKICK)

--- a/explorer/src/components/WalletSideKick/LastExtrinsics.tsx
+++ b/explorer/src/components/WalletSideKick/LastExtrinsics.tsx
@@ -13,7 +13,7 @@ import {
 } from 'constants/routes'
 import { ExtrinsicsSummaryQuery, ExtrinsicsSummaryQueryVariables } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
@@ -41,7 +41,10 @@ export const LastExtrinsics: FC<LastExtrinsicsProps> = ({ subspaceAccount }) => 
     }),
     [subspaceAccount],
   )
-  const { setIsVisible } = useSquidQuery<ExtrinsicsSummaryQuery, ExtrinsicsSummaryQueryVariables>(
+  const { setIsVisible } = useIndexersQuery<
+    ExtrinsicsSummaryQuery,
+    ExtrinsicsSummaryQueryVariables
+  >(
     QUERY_EXTRINSIC_SUMMARY,
     {
       variables,

--- a/explorer/src/components/WalletSideKick/Leaderboard.tsx
+++ b/explorer/src/components/WalletSideKick/Leaderboard.tsx
@@ -8,7 +8,7 @@ import {
   Routes,
 } from 'constants/routes'
 import { AccountsTopLeaderboardQuery, AccountsTopLeaderboardQueryVariables } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -96,7 +96,7 @@ export const useLeaderboard = (subspaceAccount: string) => {
 
 export const Leaderboard: FC<LeaderboardProps> = ({ subspaceAccount }) => {
   const { ref, inView } = useInView()
-  const { network } = useChains()
+  const { network } = useIndexers()
   const { topFarmers, topOperators, topNominators, hasTopPositions, error, loading, setIsVisible } =
     useLeaderboard(subspaceAccount)
 

--- a/explorer/src/components/WalletSideKick/Leaderboard.tsx
+++ b/explorer/src/components/WalletSideKick/Leaderboard.tsx
@@ -9,7 +9,7 @@ import {
 } from 'constants/routes'
 import { AccountsTopLeaderboardQuery, AccountsTopLeaderboardQueryVariables } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
@@ -34,7 +34,7 @@ export const useLeaderboard = (subspaceAccount: string) => {
     }),
     [],
   )
-  const { setIsVisible } = useSquidQuery<
+  const { setIsVisible } = useIndexersQuery<
     AccountsTopLeaderboardQuery,
     AccountsTopLeaderboardQueryVariables
   >(

--- a/explorer/src/components/WalletSideKick/PendingTransactions.tsx
+++ b/explorer/src/components/WalletSideKick/PendingTransactions.tsx
@@ -11,7 +11,7 @@ import { TransactionStatus } from 'constants/transaction'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { PendingTransactionQuery, PendingTransactionQueryVariables } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
@@ -30,7 +30,7 @@ dayjs.extend(relativeTime)
 
 export const PendingTransactions: FC<PendingTransactionsProps> = ({ subspaceAccount }) => {
   const { ref, inView } = useInView()
-  const { network } = useChains()
+  const { network } = useIndexers()
   const inFocus = useWindowFocus()
   const { get } = useSearchParams()
   const isSideKickOpen = get(ROUTE_EXTRA_FLAG_TYPE.WALLET_SIDEKICK)

--- a/explorer/src/components/WalletSideKick/PendingTransactions.tsx
+++ b/explorer/src/components/WalletSideKick/PendingTransactions.tsx
@@ -12,7 +12,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { PendingTransactionQuery, PendingTransactionQueryVariables } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import { useSearchParams } from 'next/navigation'
@@ -50,7 +50,7 @@ export const PendingTransactions: FC<PendingTransactionsProps> = ({ subspaceAcco
     }),
     [pendingTransactions, subspaceAccount],
   )
-  const { data, setIsVisible } = useSquidQuery<
+  const { data, setIsVisible } = useIndexersQuery<
     PendingTransactionQuery,
     PendingTransactionQueryVariables
   >(QUERY_PENDING_TX, {

--- a/explorer/src/components/WalletSideKick/StakingSummary.tsx
+++ b/explorer/src/components/WalletSideKick/StakingSummary.tsx
@@ -5,7 +5,7 @@ import { BIGINT_ZERO } from 'constants/general'
 import { ROUTE_EXTRA_FLAG_TYPE, ROUTE_FLAG_VALUE_OPEN_CLOSE, Routes } from 'constants/routes'
 import { StakingSummaryQuery, StakingSummaryQueryVariables } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
-import { useSquidQuery } from 'hooks/useSquidQuery'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
@@ -34,7 +34,7 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
     }),
     [subspaceAccount],
   )
-  const { setIsVisible } = useSquidQuery<StakingSummaryQuery, StakingSummaryQueryVariables>(
+  const { setIsVisible } = useIndexersQuery<StakingSummaryQuery, StakingSummaryQueryVariables>(
     QUERY_STAKING_SUMMARY,
     {
       variables,

--- a/explorer/src/components/WalletSideKick/StakingSummary.tsx
+++ b/explorer/src/components/WalletSideKick/StakingSummary.tsx
@@ -4,7 +4,7 @@ import { List, StyledListItem } from 'components/common/List'
 import { BIGINT_ZERO } from 'constants/general'
 import { ROUTE_EXTRA_FLAG_TYPE, ROUTE_FLAG_VALUE_OPEN_CLOSE, Routes } from 'constants/routes'
 import { StakingSummaryQuery, StakingSummaryQueryVariables } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useSquidQuery } from 'hooks/useSquidQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
@@ -22,7 +22,7 @@ interface StakingSummaryProps {
 
 export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, tokenSymbol }) => {
   const { ref, inView } = useInView()
-  const { network } = useChains()
+  const { network } = useIndexers()
   const inFocus = useWindowFocus()
   const { get } = useSearchParams()
   const isSideKickOpen = get(ROUTE_EXTRA_FLAG_TYPE.WALLET_SIDEKICK)

--- a/explorer/src/components/WalletSideKick/index.tsx
+++ b/explorer/src/components/WalletSideKick/index.tsx
@@ -11,7 +11,7 @@ import {
   ROUTE_FLAG_VALUE_OPEN_CLOSE,
 } from 'constants/routes'
 import { WalletType } from 'constants/wallet'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
@@ -115,7 +115,7 @@ export const WalletSidekick: FC = () => {
 
 const Drawer: FC<DrawerProps> = ({ isOpen, onClose }) => {
   const { push } = useRouter()
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
   const { api, actingAccount, subspaceAccount } = useWallet()
   const [tokenSymbol, setTokenSymbol] = useState<string>('')
   const [walletBalance, setWalletBalance] = useState<number>(0)

--- a/explorer/src/components/common/IndexingError.tsx
+++ b/explorer/src/components/common/IndexingError.tsx
@@ -1,7 +1,7 @@
 import { NetworkId } from '@autonomys/auto-utils'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { EXTERNAL_ROUTES } from 'constants/routes'
-import useChain from 'hooks/useChains'
+import useChain from 'hooks/useIndexers'
 import { FC, useCallback, useState } from 'react'
 
 export const IndexingError: FC = () => {

--- a/explorer/src/components/common/OutOfSyncBanner.tsx
+++ b/explorer/src/components/common/OutOfSyncBanner.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@apollo/client'
 import { activate, NetworkId } from '@autonomys/auto-utils'
 import { EXTERNAL_ROUTES } from 'constants/routes'
 import { LastBlockQuery } from 'gql/graphql'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { LAST_BLOCK } from './query'
@@ -10,7 +10,7 @@ import { LAST_BLOCK } from './query'
 const NORMAL_BLOCKS_DIVERGENCE = 120
 
 const OutOfSyncBanner: FC = () => {
-  const { network } = useChains()
+  const { network } = useIndexers()
   return (
     <div className="container mx-auto mb-4 flex grow justify-center px-5 font-['Montserrat'] md:px-[25px] 2xl:px-0">
       <div className='sticky top-0 z-50 w-full'>
@@ -46,7 +46,7 @@ const OutOfSyncBanner: FC = () => {
 }
 
 export const useOutOfSyncBanner = () => {
-  const { network } = useChains()
+  const { network } = useIndexers()
   const [lastChainBlock, setLastChainBlock] = useState<number | null>(null)
 
   const { data } = useQuery<LastBlockQuery>(LAST_BLOCK, {

--- a/explorer/src/components/common/OutOfSyncBanner.tsx
+++ b/explorer/src/components/common/OutOfSyncBanner.tsx
@@ -50,7 +50,7 @@ export const useOutOfSyncBanner = () => {
   const [lastChainBlock, setLastChainBlock] = useState<number | null>(null)
 
   const { data } = useQuery<LastBlockQuery>(LAST_BLOCK, {
-    pollInterval: 6000,
+    pollInterval: 30000,
   })
 
   const getChainLastBlock = useCallback(async () => {

--- a/explorer/src/components/common/SearchInput.tsx
+++ b/explorer/src/components/common/SearchInput.tsx
@@ -1,12 +1,12 @@
 import { useFormikContext } from 'formik'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import React, { FC } from 'react'
 import { FormValues } from './SearchBar'
 
 export const SearchInput: FC = () => {
   const { values, errors, touched, handleChange } = useFormikContext<FormValues>()
-  const { network } = useChains()
+  const { network } = useIndexers()
   const isDesktop = useMediaQuery('(min-width: 640px)')
 
   let placeholder: string

--- a/explorer/src/components/layout/ConsensusHeader.tsx
+++ b/explorer/src/components/layout/ConsensusHeader.tsx
@@ -3,7 +3,7 @@
 import { Bars3BottomRightIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
 import { LogoIcon } from 'components/icons'
 import { INTERNAL_ROUTES } from 'constants/routes'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -17,7 +17,7 @@ export const ConsensusHeader: FC = () => {
   const pathname = usePathname()
   const isDesktop = useMediaQuery('(min-width: 1024px)')
   const [isOpen, setIsOpen] = useState(false)
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   const menuList = useMemo(
     () => [

--- a/explorer/src/components/layout/DomainHeader.tsx
+++ b/explorer/src/components/layout/DomainHeader.tsx
@@ -3,7 +3,7 @@
 import { Bars3BottomRightIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
 import { LogoIcon } from 'components/icons'
 import { INTERNAL_ROUTES, ROUTES, Routes } from 'constants/routes'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -17,7 +17,7 @@ export const DomainHeader = () => {
   const pathname = usePathname()
   const isDesktop = useMediaQuery('(min-width: 1024px)')
   const [isOpen, setIsOpen] = useState(false)
-  const { network } = useChains()
+  const { network } = useIndexers()
 
   const menuList = useMemo(() => {
     const domainsChildren = ROUTES.find((item) => item.name === Routes.domains)?.children

--- a/explorer/src/components/layout/EmptyHeader.tsx
+++ b/explorer/src/components/layout/EmptyHeader.tsx
@@ -3,7 +3,7 @@
 import { Bars3BottomRightIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
 import { LogoIcon } from 'components/icons'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import Link from 'next/link'
 import { useTheme } from 'providers/ThemeProvider'
@@ -15,7 +15,7 @@ export const EmptyHeader = () => {
   const { isDark, toggleTheme } = useTheme()
   const isDesktop = useMediaQuery('(min-width: 1024px)')
   const [isOpen, setIsOpen] = useState(false)
-  const { network } = useChains()
+  const { network } = useIndexers()
 
   return (
     <header className="body-font z-9 py-[30px] font-['Montserrat'] text-gray-600">

--- a/explorer/src/components/layout/FarmingHeader.tsx
+++ b/explorer/src/components/layout/FarmingHeader.tsx
@@ -3,7 +3,7 @@
 import { Bars3BottomRightIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
 import { LogoIcon } from 'components/icons'
 import { EXTERNAL_ROUTES, INTERNAL_ROUTES, Routes } from 'constants/routes'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -17,7 +17,7 @@ export const FarmingHeader = () => {
   const pathname = usePathname()
   const isDesktop = useMediaQuery('(min-width: 1024px)')
   const [isOpen, setIsOpen] = useState(false)
-  const { network } = useChains()
+  const { network } = useIndexers()
 
   const menuList = useMemo(
     () => [

--- a/explorer/src/components/layout/HeaderChainDropdown.tsx
+++ b/explorer/src/components/layout/HeaderChainDropdown.tsx
@@ -3,12 +3,12 @@ import { Listbox, Transition } from '@headlessui/react'
 import { CheckIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
 import { AutonomysSymbol } from 'components/icons'
 import { Indexer, indexers } from 'constants/indexers'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useRouter } from 'next/navigation'
 import { FC, Fragment, useCallback, useMemo } from 'react'
 
 export const HeaderChainDropdown: FC = () => {
-  const { indexerSet, section } = useChains()
+  const { indexerSet, section } = useIndexers()
   const { push } = useRouter()
 
   const handleChainChange = useCallback(

--- a/explorer/src/components/layout/LeaderboardHeader.tsx
+++ b/explorer/src/components/layout/LeaderboardHeader.tsx
@@ -3,7 +3,7 @@
 import { Bars3BottomRightIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
 import { LogoIcon } from 'components/icons'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -17,7 +17,7 @@ export const LeaderboardHeader: FC = () => {
   const pathname = usePathname()
   const isDesktop = useMediaQuery('(min-width: 1024px)')
   const [isOpen, setIsOpen] = useState(false)
-  const { network } = useChains()
+  const { network } = useIndexers()
 
   const menuList = useMemo(
     () => [

--- a/explorer/src/components/layout/MobileHeader.tsx
+++ b/explorer/src/components/layout/MobileHeader.tsx
@@ -2,7 +2,7 @@
 
 import { MoonIcon, SunIcon } from '@heroicons/react/20/solid'
 import { LogoIcon } from 'components/icons'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { useRouter } from 'next/navigation'
 import { useTheme } from 'providers/ThemeProvider'
 import { FC, ReactNode } from 'react'
@@ -28,7 +28,7 @@ export const MobileHeader: FC<Props> = ({ isOpen, setIsOpen, menuList }) => (
 const Drawer: FC<Props> = ({ children, menuList, isOpen, setIsOpen }) => {
   const { push } = useRouter()
   const { isDark, toggleTheme } = useTheme()
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   const handleNavigate = (url: string) => {
     setIsOpen(false)

--- a/explorer/src/components/layout/NotFound/index.tsx
+++ b/explorer/src/components/layout/NotFound/index.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { ArrowButton } from 'components/common/ArrowButton'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import Link from 'next/link'
 import { FC } from 'react'
 import { NotFoundImage } from './NotFoundImage'
 
 export const NotFound: FC = () => {
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   return (
     <section className='flex h-full items-center p-16'>

--- a/explorer/src/components/layout/StakingHeader.tsx
+++ b/explorer/src/components/layout/StakingHeader.tsx
@@ -3,7 +3,7 @@
 import { Bars3BottomRightIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
 import { LogoIcon } from 'components/icons'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -17,7 +17,7 @@ export const StakingHeader = () => {
   const pathname = usePathname()
   const isDesktop = useMediaQuery('(min-width: 1024px)')
   const [isOpen, setIsOpen] = useState(false)
-  const { network } = useChains()
+  const { network } = useIndexers()
 
   const menuList = useMemo(
     () => [

--- a/explorer/src/hooks/useChains.ts
+++ b/explorer/src/hooks/useChains.ts
@@ -1,12 +1,12 @@
 'use client'
 
-import { ChainContext, ChainContextValue } from 'providers/ChainProvider'
+import { IndexersContext, IndexersContextValue } from 'providers/IndexersProvider'
 import { useContext } from 'react'
 
-export const useChains = (): ChainContextValue => {
-  const context = useContext(ChainContext)
+export const useChains = (): IndexersContextValue => {
+  const context = useContext(IndexersContext)
 
-  if (!context) throw new Error('ChainContext must be used within ChainProvider')
+  if (!context) throw new Error('IndexersContext must be used within IndexersProvider')
 
   return context
 }

--- a/explorer/src/hooks/useIndexers.ts
+++ b/explorer/src/hooks/useIndexers.ts
@@ -3,7 +3,7 @@
 import { IndexersContext, IndexersContextValue } from 'providers/IndexersProvider'
 import { useContext } from 'react'
 
-export const useChains = (): IndexersContextValue => {
+export const useIndexers = (): IndexersContextValue => {
   const context = useContext(IndexersContext)
 
   if (!context) throw new Error('IndexersContext must be used within IndexersProvider')
@@ -11,4 +11,4 @@ export const useChains = (): IndexersContextValue => {
   return context
 }
 
-export default useChains
+export default useIndexers

--- a/explorer/src/hooks/useIndexersQuery.ts
+++ b/explorer/src/hooks/useIndexersQuery.ts
@@ -14,7 +14,7 @@ interface UseCustomQueryOptions<TData, TVariables extends OperationVariables>
   pollInterval?: number
 }
 
-export const useSquidQuery = <TData, TVariables extends OperationVariables>(
+export const useIndexersQuery = <TData, TVariables extends OperationVariables>(
   query: DocumentNode,
   options: UseCustomQueryOptions<TData, TVariables>,
   section?: ExplorerSection,

--- a/explorer/src/hooks/useSearch.ts
+++ b/explorer/src/hooks/useSearch.ts
@@ -7,7 +7,7 @@ import { INTERNAL_ROUTES } from 'constants/routes'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { formatAddress } from 'utils//formatAddress'
-import useChains from './useChains'
+import useIndexers from './useIndexers'
 
 type Values = {
   handleSearch: (term: string, searchType: number) => void
@@ -17,7 +17,7 @@ type Values = {
 export const useSearch = (): Values => {
   const [isSearching, setIsSearching] = useState(false)
   const { push } = useRouter()
-  const { network, section } = useChains()
+  const { network, section } = useIndexers()
 
   const [getResults] = useLazyQuery(GET_RESULTS, { fetchPolicy: 'network-only' })
 

--- a/explorer/src/hooks/useTxHelper.ts
+++ b/explorer/src/hooks/useTxHelper.ts
@@ -1,7 +1,7 @@
 import type { ISubmittableResult, Signer, SubmittableExtrinsic } from '@autonomys/auto-utils'
 import { sendGAEvent } from '@next/third-parties/google'
 import { TransactionStatus } from 'constants/transaction'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import useWallet from 'hooks/useWallet'
 import { usePathname } from 'next/navigation'
 import { useCallback } from 'react'
@@ -23,7 +23,7 @@ interface SendAndSaveTx {
 }
 
 export const useTxHelper = () => {
-  const { network } = useChains()
+  const { network } = useIndexers()
   const { api, actingAccount, subspaceAccount, injector } = useWallet()
   const { addPendingTransactions, getNextNonceForAccount } = useTransactionsStates()
   const pathname = usePathname()

--- a/explorer/src/hooks/useWallet.ts
+++ b/explorer/src/hooks/useWallet.ts
@@ -4,7 +4,7 @@ import { useContext } from 'react'
 export const useWallet = (): WalletContextValue => {
   const context = useContext(WalletContext)
 
-  if (!context) throw new Error('ChainContext must be used within ChainProvider')
+  if (!context) throw new Error('ChainContext must be used within WalletProvider')
 
   return context
 }

--- a/explorer/src/providers/IndexersProvider.tsx
+++ b/explorer/src/providers/IndexersProvider.tsx
@@ -14,7 +14,7 @@ import { Routes } from 'constants/routes'
 import { FC, ReactNode, createContext, useCallback, useMemo, useState } from 'react'
 import { getTokenDecimals, getTokenSymbol } from 'utils/network'
 
-export type ChainContextValue = {
+export type IndexersContextValue = {
   indexerSet: Indexer
   network: NetworkId
   section: Routes
@@ -24,7 +24,7 @@ export type ChainContextValue = {
   setSection: (section: Routes) => void
 }
 
-export const ChainContext = createContext<ChainContextValue>(
+export const IndexersContext = createContext<IndexersContextValue>(
   // @ts-expect-error It's a good practice not to give a default value even though the linter tells you so
   {},
 )
@@ -33,11 +33,9 @@ type Props = {
   children?: ReactNode
 }
 
-interface SelectedChainProps extends Props {
-  indexerSet: Indexer
-}
-
-const SelectedChainProvider: FC<SelectedChainProps> = ({ indexerSet, children }) => {
+export const IndexersProvider: FC<Props> = ({ children }) => {
+  const [indexerSet, _setIndexerSet] = useState<Indexer>(defaultIndexer)
+  const [section, setSection] = useState<Routes>(Routes.consensus)
   const httpLink = createHttpLink({
     uri: () => indexerSet.indexer,
   })
@@ -51,13 +49,6 @@ const SelectedChainProvider: FC<SelectedChainProps> = ({ indexerSet, children })
     [httpLink],
   )
 
-  return <ApolloProvider client={client}>{children}</ApolloProvider>
-}
-
-export const ChainProvider: FC<Props> = ({ children }) => {
-  const [indexerSet, _setIndexerSet] = useState<Indexer>(defaultIndexer)
-  const [section, setSection] = useState<Routes>(Routes.consensus)
-
   const setIndexerSet = useCallback(
     (indexer: Indexer) => {
       _setIndexerSet(indexer)
@@ -66,7 +57,7 @@ export const ChainProvider: FC<Props> = ({ children }) => {
   )
 
   return (
-    <ChainContext.Provider
+    <IndexersContext.Provider
       value={{
         indexerSet,
         network: indexerSet.network,
@@ -77,7 +68,7 @@ export const ChainProvider: FC<Props> = ({ children }) => {
         setSection,
       }}
     >
-      <SelectedChainProvider indexerSet={indexerSet}>{children}</SelectedChainProvider>
-    </ChainContext.Provider>
+      <ApolloProvider client={client}>{children}</ApolloProvider>
+    </IndexersContext.Provider>
   )
 }

--- a/explorer/src/providers/index.tsx
+++ b/explorer/src/providers/index.tsx
@@ -6,7 +6,7 @@ import useChains from 'hooks/useChains'
 import { SessionProvider } from 'next-auth/react'
 import dynamic from 'next/dynamic'
 import { usePathname } from 'next/navigation'
-import { ChainProvider } from 'providers/ChainProvider'
+import { IndexersProvider } from 'providers/IndexersProvider'
 import { ThemeProvider } from 'providers/ThemeProvider'
 import { FC, ReactNode, useEffect } from 'react'
 
@@ -52,7 +52,7 @@ const UpdateSelectedChainByPath = ({ children }: Props) => {
 
 export const Provider: FC<ProviderProps> = ({ children }) => {
   return (
-    <ChainProvider>
+    <IndexersProvider>
       <ThemeProvider>
         <SessionProvider>
           <WalletProvider>
@@ -60,6 +60,6 @@ export const Provider: FC<ProviderProps> = ({ children }) => {
           </WalletProvider>
         </SessionProvider>
       </ThemeProvider>
-    </ChainProvider>
+    </IndexersProvider>
   )
 }

--- a/explorer/src/providers/index.tsx
+++ b/explorer/src/providers/index.tsx
@@ -2,7 +2,7 @@
 
 import { indexers } from 'constants/indexers'
 import { Routes } from 'constants/routes'
-import useChains from 'hooks/useChains'
+import useIndexers from 'hooks/useIndexers'
 import { SessionProvider } from 'next-auth/react'
 import dynamic from 'next/dynamic'
 import { usePathname } from 'next/navigation'
@@ -26,7 +26,7 @@ const WalletProvider = dynamic(
 )
 
 const UpdateSelectedChainByPath = ({ children }: Props) => {
-  const { setIndexerSet, setSection, network, section } = useChains()
+  const { setIndexerSet, setSection, network, section } = useIndexers()
 
   const pathname = usePathname()
 


### PR DESCRIPTION
### **User description**
## Improve Apollo config

The last commit of this PR is the most important. It adds error handling at the Apollo level to prevent failed queries from bubbling up on the page directly. Since we fetch data every 6 seconds on most pages, it's possible that once in a while, a query gets dropped by the server due to a heavy load or a bad connection. Especially as many user let the app open for long period of time. So this will send us a slack error report, but won't display the 404 on the page, it will instead retry the query.

There are a few other changes:
- Move the out of sync pooling interval to 30 sec, this will reduce the amount of query that are not super critical
- Rename the provider in charge of Apollo to IndexersProvider
- Rename the hooks in charge of query to useIndexers


___

### **PR Type**
enhancement, error handling


___

### **Description**
- Replaced `useChains` with `useIndexers` across multiple components to improve consistency and clarity.
- Replaced `useSquidQuery` with `useIndexersQuery` to align with the new naming convention.
- Enhanced error handling in `IndexersProvider` using Apollo Client's `onError` link.
- Improved logging by modifying the log path and reducing the data slice limit.
- Removed the `useChains` hook and added a new `useIndexers` hook.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Improve logging path and data slice limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/app/api/log/[...params]/route.ts

<li>Modified the log path to remove '/api/log/' prefix.<br> <li> Reduced the log data slice limit from 25000 to 5000 characters.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/989/files#diff-775e15c838a93fa3e47264af4ae4f58effb57ea07ed5d111389c8e30a41e2d7b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Account.tsx</strong><dd><code>Replace useSquidQuery with useIndexersQuery in Account component</code></dd></summary>
<hr>

explorer/src/components/Consensus/Account/Account.tsx

<li>Replaced <code>useSquidQuery</code> with <code>useIndexersQuery</code>.<br> <li> Updated import from <code>useSquidQuery</code> to <code>useIndexersQuery</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/989/files#diff-c1e1c97b2238837cd4425fa878430ea87682d1e57d3f70d0c394e1413ba0a0a8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountBalanceStats.tsx</strong><dd><code>Replace useChains with useIndexers in AccountBalanceStats</code></dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountBalanceStats.tsx

<li>Replaced <code>useChains</code> with <code>useIndexers</code>.<br> <li> Updated import from <code>useChains</code> to <code>useIndexers</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/989/files#diff-fce164239457682949590c3fe9f5a5c9aab637655afb22388a442b82d20ef279">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountDetailsCard.tsx</strong><dd><code>Replace useChains with useIndexers in AccountDetailsCard</code>&nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountDetailsCard.tsx

<li>Replaced <code>useChains</code> with <code>useIndexers</code>.<br> <li> Updated import from <code>useChains</code> to <code>useIndexers</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/989/files#diff-6d78795a8ba4f5c57c45868a8a37efc2ce7396f2ce7337b2951ddc571cfec108">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountExtrinsicList.tsx</strong><dd><code>Replace useSquidQuery with useIndexersQuery in AccountExtrinsicList</code></dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx

<li>Replaced <code>useSquidQuery</code> with <code>useIndexersQuery</code>.<br> <li> Updated import from <code>useSquidQuery</code> to <code>useIndexersQuery</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/989/files#diff-bda77c8265dae0962030dcf3d0533e2bf7965a6829d8ff37f77c4bdf3b7f9d9e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useChains.ts</strong><dd><code>Remove useChains hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/hooks/useChains.ts

- Removed the `useChains` hook.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/989/files#diff-c26b2c7a8d9d1a68e4629e99f2368419768b00e50e1c82b17263424da0de712e">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useIndexers.ts</strong><dd><code>Add useIndexers hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/hooks/useIndexers.ts

- Added new `useIndexers` hook.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/989/files#diff-bb751134e01612fcb5807386f83d5bdae54050c01a2b2836c8e06a6fd7e1654f">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useIndexersQuery.ts</strong><dd><code>Rename useSquidQuery to useIndexersQuery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/hooks/useIndexersQuery.ts

- Renamed `useSquidQuery` to `useIndexersQuery`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/989/files#diff-9d4a9bc9400a046e2f9b3da6ff03687f0ff1f3504b2843510a82126e54da4345">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IndexersProvider.tsx</strong><dd><code>Enhance IndexersProvider with error handling and context renaming</code></dd></summary>
<hr>

explorer/src/providers/IndexersProvider.tsx

<li>Renamed <code>ChainContext</code> to <code>IndexersContext</code>.<br> <li> Added error handling with <code>onError</code> for Apollo Client.<br> <li> Updated default options for Apollo Client.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/989/files#diff-5a184bb4cbe0f1750bfaeb1c9a22db677287dc769ae9e36bd1eef1e8b23ac81c">+44/-19</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information