### PR TITLE
Fix details page sub-list, improve sorting and caching

### DIFF
--- a/explorer/gql/graphql.ts
+++ b/explorer/gql/graphql.ts
@@ -16032,7 +16032,7 @@ export type ExtrinsicsByAccountIdQueryVariables = Exact<{
 }>;
 
 
-export type ExtrinsicsByAccountIdQuery = { __typename?: 'query_root', consensus_extrinsics_aggregate: { __typename?: 'consensus_extrinsics_aggregate', aggregate?: { __typename?: 'consensus_extrinsics_aggregate_fields', count: number } | null }, consensus_extrinsics: Array<{ __typename?: 'consensus_extrinsics', id: string, hash: string, name: string, success: boolean, block_height: any, timestamp: any, index_in_block: number }> };
+export type ExtrinsicsByAccountIdQuery = { __typename?: 'query_root', consensus_extrinsics_aggregate: { __typename?: 'consensus_extrinsics_aggregate', aggregate?: { __typename?: 'consensus_extrinsics_aggregate_fields', count: number } | null }, consensus_extrinsics: Array<{ __typename?: 'consensus_extrinsics', id: string, sort_id: string, hash: string, name: string, success: boolean, block_height: any, timestamp: any, index_in_block: number }> };
 
 export type TransfersByAccountIdQueryVariables = Exact<{
   limit: Scalars['Int']['input'];
@@ -16083,6 +16083,7 @@ export type ExtrinsicsByBlockIdQueryVariables = Exact<{
   blockId: Scalars['numeric']['input'];
   limit: Scalars['Int']['input'];
   offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<Consensus_Extrinsics_Order_By> | Consensus_Extrinsics_Order_By>;
 }>;
 
 
@@ -16092,6 +16093,7 @@ export type EventsByBlockIdQueryVariables = Exact<{
   blockId: Scalars['numeric']['input'];
   limit: Scalars['Int']['input'];
   offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<Consensus_Events_Order_By> | Consensus_Events_Order_By>;
 }>;
 
 
@@ -16136,7 +16138,17 @@ export type ExtrinsicsByIdQueryVariables = Exact<{
 }>;
 
 
-export type ExtrinsicsByIdQuery = { __typename?: 'query_root', consensus_extrinsics: Array<{ __typename?: 'consensus_extrinsics', id: string, index_in_block: number, hash: string, block_height: any, timestamp: any, signature: string, success: boolean, tip: any, args: string, signer: string, name: string, events: Array<{ __typename?: 'consensus_events', id: string, phase: string, timestamp: any, name: string, args: string, extrinsic_id: string }> }> };
+export type ExtrinsicsByIdQuery = { __typename?: 'query_root', consensus_extrinsics: Array<{ __typename?: 'consensus_extrinsics', id: string, index_in_block: number, hash: string, block_height: any, timestamp: any, signature: string, success: boolean, tip: any, args: string, signer: string, name: string, events_aggregate: { __typename?: 'consensus_events_aggregate', aggregate?: { __typename?: 'consensus_events_aggregate_fields', count: number } | null } }> };
+
+export type EventsByExtrinsicIdQueryVariables = Exact<{
+  extrinsicId: Scalars['String']['input'];
+  limit: Scalars['Int']['input'];
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<Consensus_Events_Order_By> | Consensus_Events_Order_By>;
+}>;
+
+
+export type EventsByExtrinsicIdQuery = { __typename?: 'query_root', consensus_events_aggregate: { __typename?: 'consensus_events_aggregate', aggregate?: { __typename?: 'consensus_events_aggregate_fields', count: number } | null }, consensus_events: Array<{ __typename?: 'consensus_events', id: string, name: string, phase: string, index_in_block: any, block_height: any, extrinsic_id: string }> };
 
 export type ExtrinsicsByHashQueryVariables = Exact<{
   hash: Scalars['String']['input'];

--- a/explorer/src/components/Consensus/Account/Account.tsx
+++ b/explorer/src/components/Consensus/Account/Account.tsx
@@ -41,9 +41,7 @@ export const Account: FC = () => {
     'account',
   )
 
-  const {
-    consensus: { account: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.account)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx
@@ -85,11 +85,12 @@ export const AccountExtrinsicList: FC<Props> = ({ accountId }) => {
     'accountExtrinsic',
   )
 
-  const accountExtrinsic = useQueryStates((state) => state.consensus.accountExtrinsic)
+  const consensusEntry = useQueryStates((state) => state.consensus.accountExtrinsic)
 
-  const data = useMemo(() => {
-    if (hasValue(accountExtrinsic)) return accountExtrinsic.value
-  }, [accountExtrinsic])
+  const extrinsics = useMemo(
+    () => hasValue(consensusEntry) && consensusEntry.value.consensus_extrinsics,
+    [consensusEntry],
+  )
 
   const fullDataDownloader = useCallback(
     () =>
@@ -97,13 +98,12 @@ export const AccountExtrinsicList: FC<Props> = ({ accountId }) => {
     [apolloClient, variables],
   )
 
-  const extrinsics = useMemo(() => data && data.consensus_extrinsics, [data])
   const totalCount = useMemo(
     () =>
-      data && data.consensus_extrinsics_aggregate.aggregate
-        ? data.consensus_extrinsics_aggregate.aggregate.count
+      hasValue(consensusEntry) && consensusEntry.value.consensus_extrinsics_aggregate.aggregate
+        ? consensusEntry.value.consensus_extrinsics_aggregate.aggregate.count
         : 0,
-    [data],
+    [consensusEntry],
   )
   const pageCount = useMemo(
     () => (totalCount ? countTablePages(totalCount, pagination.pageSize) : 0),
@@ -176,10 +176,10 @@ export const AccountExtrinsicList: FC<Props> = ({ accountId }) => {
   )
 
   const noData = useMemo(() => {
-    if (loading || isLoading(accountExtrinsic)) return <Spinner isSmall />
-    if (!data) return <NotFound />
+    if (loading || isLoading(consensusEntry)) return <Spinner isSmall />
+    if (!hasValue(consensusEntry)) return <NotFound />
     return null
-  }, [data, loading, accountExtrinsic])
+  }, [consensusEntry, loading])
 
   useEffect(() => {
     setIsVisible(inView)

--- a/explorer/src/components/Consensus/Account/AccountList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountList.tsx
@@ -155,9 +155,7 @@ export const AccountList: FC = () => {
     TABLE,
   )
 
-  const {
-    consensus: { accounts: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.accounts)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Account/AccountRewardGraph.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardGraph.tsx
@@ -36,9 +36,7 @@ export const AccountRewardGraph: FC<Props> = ({ accountId, total }) => {
     skip: !inFocus,
   })
 
-  const {
-    consensus: { accountRewardGraph: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.accountRewardGraph)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Account/AccountRewardList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardList.tsx
@@ -73,9 +73,7 @@ export const AccountRewardList: FC = () => {
     'accountReward',
   )
 
-  const {
-    consensus: { accountReward: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.accountReward)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
@@ -23,6 +23,7 @@ import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
+import { hasValue, isLoading, useQueryStates } from 'states/query'
 import type { Cell } from 'types/table'
 import { downloadFullData } from 'utils/downloadFullData'
 import { bigNumberToNumber } from 'utils/number'
@@ -75,28 +76,38 @@ export const AccountTransfersList: FC<Props> = ({ accountId }) => {
     }
   }, [orderBy, pagination.pageIndex, pagination.pageSize, where])
 
-  const { data, loading, setIsVisible } = useIndexersQuery<
+  const { loading, setIsVisible } = useIndexersQuery<
     TransfersByAccountIdQuery,
     TransfersByAccountIdQueryVariables
-  >(QUERY_ACCOUNT_TRANSFERS, {
-    variables,
-    skip: !inFocus,
-    pollInterval: 6000,
-    context: { clientName: 'accounts' },
-  })
+  >(
+    QUERY_ACCOUNT_TRANSFERS,
+    {
+      variables,
+      skip: !inFocus,
+      pollInterval: 6000,
+      context: { clientName: 'accounts' },
+    },
+    Routes.consensus,
+    'accountTransfers',
+  )
+
+  const consensusEntry = useQueryStates((state) => state.consensus.accountTransfers)
+
+  const transfers = useMemo(
+    () => hasValue(consensusEntry) && consensusEntry.value.consensus_transfers,
+    [consensusEntry],
+  )
 
   const fullDataDownloader = useCallback(
     () => downloadFullData(apolloClient, QUERY_ACCOUNT_TRANSFERS, 'consensus_transfers', variables),
     [apolloClient, variables],
   )
-
-  const transfers = useMemo(() => data && data.consensus_transfers, [data])
   const totalCount = useMemo(
     () =>
-      data && data.consensus_transfers_aggregate.aggregate
-        ? data.consensus_transfers_aggregate.aggregate.count
+      hasValue(consensusEntry) && consensusEntry.value.consensus_transfers_aggregate.aggregate
+        ? consensusEntry.value.consensus_transfers_aggregate.aggregate.count
         : 0,
-    [data],
+    [consensusEntry],
   )
   const pageCount = useMemo(
     () => (totalCount ? countTablePages(totalCount, pagination.pageSize) : 0),
@@ -234,10 +245,10 @@ export const AccountTransfersList: FC<Props> = ({ accountId }) => {
   )
 
   const noData = useMemo(() => {
-    if (loading) return <Spinner isSmall />
-    if (!data) return <NotFound />
+    if (loading || isLoading(consensusEntry)) return <Spinner isSmall />
+    if (!hasValue(consensusEntry)) return <NotFound />
     return null
-  }, [data, loading])
+  }, [consensusEntry, loading])
 
   useEffect(() => {
     setIsVisible(inView)

--- a/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountTransfersList.tsx
@@ -86,12 +86,8 @@ export const AccountTransfersList: FC<Props> = ({ accountId }) => {
   })
 
   const fullDataDownloader = useCallback(
-    () =>
-      downloadFullData(apolloClient, QUERY_ACCOUNT_TRANSFERS, 'extrinsicsConnection', {
-        orderBy,
-        where,
-      }),
-    [apolloClient, orderBy, where],
+    () => downloadFullData(apolloClient, QUERY_ACCOUNT_TRANSFERS, 'consensus_transfers', variables),
+    [apolloClient, variables],
   )
 
   const transfers = useMemo(() => data && data.consensus_transfers, [data])
@@ -260,7 +256,7 @@ export const AccountTransfersList: FC<Props> = ({ accountId }) => {
             pagination={pagination}
             pageCount={pageCount}
             onPaginationChange={setPagination}
-            filename='account-extrinsic-list'
+            filename='account-transfers-list'
             fullDataDownloader={fullDataDownloader}
           />
         ) : (

--- a/explorer/src/components/Consensus/Account/BalanceHistory.tsx
+++ b/explorer/src/components/Consensus/Account/BalanceHistory.tsx
@@ -21,6 +21,7 @@ import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
+import { hasValue, isLoading, useQueryStates } from 'states/query'
 import type { Cell } from 'types/table'
 import { downloadFullData } from 'utils/downloadFullData'
 import { bigNumberToNumber } from 'utils/number'
@@ -67,14 +68,26 @@ export const BalanceHistory: FC<Props> = ({ accountId }) => {
     }
   }, [orderBy, pagination.pageIndex, pagination.pageSize, where])
 
-  const { data, loading, setIsVisible } = useIndexersQuery<
+  const { loading, setIsVisible } = useIndexersQuery<
     BalanceHistoryByAccountIdQuery,
     BalanceHistoryByAccountIdQueryVariables
-  >(QUERY_ACCOUNT_BALANCE_HISTORY, {
-    variables,
-    skip: !inFocus,
-    pollInterval: 6000,
-  })
+  >(
+    QUERY_ACCOUNT_BALANCE_HISTORY,
+    {
+      variables,
+      skip: !inFocus,
+      pollInterval: 6000,
+    },
+    Routes.consensus,
+    'accountBalanceHistory',
+  )
+
+  const consensusEntry = useQueryStates((state) => state.consensus.accountBalanceHistory)
+
+  const histories = useMemo(
+    () => hasValue(consensusEntry) && consensusEntry.value.consensus_account_histories,
+    [consensusEntry],
+  )
 
   const fullDataDownloader = useCallback(
     () =>
@@ -87,13 +100,12 @@ export const BalanceHistory: FC<Props> = ({ accountId }) => {
     [apolloClient, variables],
   )
 
-  const histories = useMemo(() => data && data.consensus_account_histories, [data])
   const totalCount = useMemo(
     () =>
-      data && data.consensus_account_histories_aggregate
-        ? data.consensus_account_histories_aggregate.aggregate?.count
+      hasValue(consensusEntry) && consensusEntry.value.consensus_account_histories_aggregate
+        ? consensusEntry.value.consensus_account_histories_aggregate.aggregate?.count
         : 0,
-    [data],
+    [consensusEntry],
   )
   const pageCount = useMemo(
     () => (totalCount ? countTablePages(totalCount, pagination.pageSize) : 0),
@@ -171,10 +183,10 @@ export const BalanceHistory: FC<Props> = ({ accountId }) => {
   )
 
   const noData = useMemo(() => {
-    if (loading) return <Spinner isSmall />
-    if (!data) return <NotFound />
+    if (loading || isLoading(consensusEntry)) return <Spinner isSmall />
+    if (!hasValue(consensusEntry)) return <NotFound />
     return null
-  }, [data, loading])
+  }, [consensusEntry, loading])
 
   useEffect(() => {
     setIsVisible(inView)

--- a/explorer/src/components/Consensus/Account/BalanceHistory.tsx
+++ b/explorer/src/components/Consensus/Account/BalanceHistory.tsx
@@ -78,11 +78,13 @@ export const BalanceHistory: FC<Props> = ({ accountId }) => {
 
   const fullDataDownloader = useCallback(
     () =>
-      downloadFullData(apolloClient, QUERY_ACCOUNT_BALANCE_HISTORY, 'consensus_account_histories', {
-        orderBy,
-        where,
-      }),
-    [apolloClient, orderBy, where],
+      downloadFullData(
+        apolloClient,
+        QUERY_ACCOUNT_BALANCE_HISTORY,
+        'consensus_account_histories',
+        variables,
+      ),
+    [apolloClient, variables],
   )
 
   const histories = useMemo(() => data && data.consensus_account_histories, [data])

--- a/explorer/src/components/Consensus/Account/query.ts
+++ b/explorer/src/components/Consensus/Account/query.ts
@@ -131,6 +131,7 @@ export const QUERY_ACCOUNT_EXTRINSICS = gql`
     }
     consensus_extrinsics(order_by: $orderBy, limit: $limit, offset: $offset, where: $where) {
       id
+      sort_id
       hash
       name
       success

--- a/explorer/src/components/Consensus/Block/Block.tsx
+++ b/explorer/src/components/Consensus/Block/Block.tsx
@@ -32,9 +32,7 @@ export const Block: FC = () => {
     'block',
   )
 
-  const {
-    consensus: { block: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.block)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
@@ -73,10 +73,10 @@ export const BlockDetailsEventList: FC = () => {
     'blockDetailsEvent',
   )
 
-  const blockDetailsEvent = useQueryStates((state) => state.consensus.blockDetailsEvent)
+  const consensusEntry = useQueryStates((state) => state.consensus.blockDetailsEvent)
   const events = useMemo(
-    () => hasValue(blockDetailsEvent) && blockDetailsEvent.value.consensus_events,
-    [blockDetailsEvent],
+    () => hasValue(consensusEntry) && consensusEntry.value.consensus_events,
+    [consensusEntry],
   )
 
   const columns = useMemo(
@@ -129,17 +129,23 @@ export const BlockDetailsEventList: FC = () => {
     [apolloClient, variables],
   )
 
-  const totalCount = useMemo(() => (events ? events.length : 0), [events])
+  const totalCount = useMemo(
+    () =>
+      hasValue(consensusEntry) && consensusEntry.value.consensus_events_aggregate.aggregate
+        ? consensusEntry.value.consensus_events_aggregate.aggregate.count
+        : 0,
+    [consensusEntry],
+  )
   const pageCount = useMemo(
     () => countTablePages(totalCount, pagination.pageSize),
     [totalCount, pagination],
   )
 
   const noData = useMemo(() => {
-    if (loading || isLoading(blockDetailsEvent)) return <Spinner isSmall />
-    if (!hasValue(blockDetailsEvent)) return <NotFound />
+    if (loading || isLoading(consensusEntry)) return <Spinner isSmall />
+    if (!hasValue(consensusEntry)) return <NotFound />
     return null
-  }, [loading, blockDetailsEvent])
+  }, [loading, consensusEntry])
 
   useEffect(() => {
     setIsVisible(inView)

--- a/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
@@ -5,8 +5,12 @@ import type { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
 import { Spinner } from 'components/common/Spinner'
 import { PAGE_SIZE } from 'constants/general'
-import { INTERNAL_ROUTES } from 'constants/routes'
-import { EventsByBlockIdQuery, EventsByBlockIdQueryVariables } from 'gql/graphql'
+import { INTERNAL_ROUTES, Routes } from 'constants/routes'
+import {
+  EventsByBlockIdQuery,
+  EventsByBlockIdQueryVariables,
+  Order_By as OrderBy,
+} from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
 import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
@@ -14,9 +18,9 @@ import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
+import { hasValue, isLoading, useQueryStates } from 'states/query'
 import type { Cell } from 'types/table'
 import { downloadFullData } from 'utils/downloadFullData'
-import { sort } from 'utils/sort'
 import { countTablePages } from 'utils/table'
 import { NotFound } from '../../layout/NotFound'
 import { QUERY_BLOCK_EVENTS } from './query'
@@ -28,14 +32,23 @@ export const BlockDetailsEventList: FC = () => {
   const { blockId } = useParams()
   const { network, section } = useIndexers()
   const apolloClient = useApolloClient()
-  const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'sort_id', desc: false }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,
     pageIndex: 0,
   })
   const inFocus = useWindowFocus()
 
-  const orderBy = useMemo(() => sort(sorting, 'id_ASC'), [sorting])
+  const orderBy = useMemo(
+    () =>
+      sorting && sorting.length > 0
+        ? sorting[0].id.endsWith('aggregate')
+          ? { [sorting[0].id]: sorting[0].desc ? { count: OrderBy.Desc } : { count: OrderBy.Asc } }
+          : { [sorting[0].id]: sorting[0].desc ? OrderBy.Desc : OrderBy.Asc }
+        : // eslint-disable-next-line camelcase
+          { sort_id: OrderBy.Desc },
+    [sorting],
+  )
 
   const variables = useMemo(
     () => ({
@@ -47,29 +60,38 @@ export const BlockDetailsEventList: FC = () => {
     [pagination.pageSize, pagination.pageIndex, orderBy, blockId],
   )
 
-  const { data, loading, setIsVisible } = useIndexersQuery<
+  const { loading, setIsVisible } = useIndexersQuery<
     EventsByBlockIdQuery,
     EventsByBlockIdQueryVariables
-  >(QUERY_BLOCK_EVENTS, {
-    variables,
-    skip: !inFocus,
-  })
+  >(
+    QUERY_BLOCK_EVENTS,
+    {
+      variables,
+      skip: !inFocus,
+    },
+    Routes.consensus,
+    'blockDetailsEvent',
+  )
 
-  const events = useMemo(() => data && data.consensus_events, [data])
+  const blockDetailsEvent = useQueryStates((state) => state.consensus.blockDetailsEvent)
+  const events = useMemo(
+    () => hasValue(blockDetailsEvent) && blockDetailsEvent.value.consensus_events,
+    [blockDetailsEvent],
+  )
 
   const columns = useMemo(
     () => [
       {
-        accessorKey: 'id',
+        accessorKey: 'sort_id',
         header: 'Event Id',
-        enableSorting: false,
+        enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
           <div className='flex w-full gap-1' key={`${row.index}-block-event-id`}>
             <Link
               className='w-full hover:text-primaryAccent'
               href={INTERNAL_ROUTES.events.id.page(network, section, row.original.id)}
             >
-              {`${row.original.block_height}-${row.index}`}
+              {row.original.id}
             </Link>
           </div>
         ),
@@ -103,12 +125,8 @@ export const BlockDetailsEventList: FC = () => {
   )
 
   const fullDataDownloader = useCallback(
-    () =>
-      downloadFullData(apolloClient, QUERY_BLOCK_EVENTS, 'eventsConnection', {
-        first: 10,
-        orderBy,
-      }),
-    [apolloClient, orderBy],
+    () => downloadFullData(apolloClient, QUERY_BLOCK_EVENTS, 'consensus_events', variables),
+    [apolloClient, variables],
   )
 
   const totalCount = useMemo(() => (events ? events.length : 0), [events])
@@ -118,10 +136,10 @@ export const BlockDetailsEventList: FC = () => {
   )
 
   const noData = useMemo(() => {
-    if (loading) return <Spinner isSmall />
-    if (!data) return <NotFound />
+    if (loading || isLoading(blockDetailsEvent)) return <Spinner isSmall />
+    if (!hasValue(blockDetailsEvent)) return <NotFound />
     return null
-  }, [data, loading])
+  }, [loading, blockDetailsEvent])
 
   useEffect(() => {
     setIsVisible(inView)

--- a/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
@@ -1,21 +1,28 @@
 'use client'
 
+import { useApolloClient } from '@apollo/client'
 import { shortString } from '@autonomys/auto-utils'
 import type { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
 import { Spinner } from 'components/common/Spinner'
 import { StatusIcon } from 'components/common/StatusIcon'
 import { PAGE_SIZE } from 'constants/general'
-import { INTERNAL_ROUTES } from 'constants/routes'
-import { ExtrinsicsByBlockIdQuery, ExtrinsicsByBlockIdQueryVariables } from 'gql/graphql'
+import { INTERNAL_ROUTES, Routes } from 'constants/routes'
+import {
+  ExtrinsicsByBlockIdQuery,
+  ExtrinsicsByBlockIdQueryVariables,
+  Order_By as OrderBy,
+} from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
 import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { FC, useEffect, useMemo, useState } from 'react'
+import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
+import { hasValue, isLoading, useQueryStates } from 'states/query'
 import type { Cell } from 'types/table'
+import { downloadFullData } from 'utils/downloadFullData'
 import { countTablePages } from 'utils/table'
 import { utcToLocalRelativeTime } from 'utils/time'
 import { NotFound } from '../../layout/NotFound'
@@ -31,72 +38,100 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({ isDesktop = false }) => {
   const { ref, inView } = useInView()
   const { blockId } = useParams()
   const { network, section } = useIndexers()
-  const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
+  const apolloClient = useApolloClient()
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'sort_id', desc: false }])
   const [pagination, setPagination] = useState({
-    pageSize: PAGE_SIZE,
+    pageSize: isDesktop ? PAGE_SIZE : 5,
     pageIndex: 0,
   })
   const inFocus = useWindowFocus()
 
-  const limit = useMemo(() => (isDesktop ? 10 : 5), [isDesktop])
-  const { data, loading, setIsVisible } = useIndexersQuery<
+  const orderBy = useMemo(
+    () =>
+      sorting && sorting.length > 0
+        ? sorting[0].id.endsWith('aggregate')
+          ? { [sorting[0].id]: sorting[0].desc ? { count: OrderBy.Desc } : { count: OrderBy.Asc } }
+          : { [sorting[0].id]: sorting[0].desc ? OrderBy.Desc : OrderBy.Asc }
+        : // eslint-disable-next-line camelcase
+          { sort_id: OrderBy.Desc },
+    [sorting],
+  )
+
+  const variables = useMemo(
+    () => ({
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex > 0 ? pagination.pageIndex * pagination.pageSize : undefined,
+      orderBy,
+      blockId: Number(blockId),
+    }),
+    [pagination.pageSize, pagination.pageIndex, orderBy, blockId],
+  )
+
+  const { loading, setIsVisible } = useIndexersQuery<
     ExtrinsicsByBlockIdQuery,
     ExtrinsicsByBlockIdQueryVariables
-  >(QUERY_BLOCK_EXTRINSICS, {
-    variables: { blockId: Number(blockId), limit },
-    skip: !inFocus,
-  })
+  >(
+    QUERY_BLOCK_EXTRINSICS,
+    {
+      variables,
+      skip: !inFocus,
+    },
+    Routes.consensus,
+    'blockDetailsExtrinsic',
+  )
 
-  const extrinsics = useMemo(() => data && data.consensus_extrinsics, [data])
+  const blockDetailsExtrinsic = useQueryStates((state) => state.consensus.blockDetailsExtrinsic)
+  const extrinsics = useMemo(
+    () => hasValue(blockDetailsExtrinsic) && blockDetailsExtrinsic.value.consensus_extrinsics,
+    [blockDetailsExtrinsic],
+  )
 
   const columns = useMemo(
     () => [
       {
-        accessorKey: 'block',
+        accessorKey: 'sort_id',
         header: 'Extrinsic Id',
-        enableSorting: false,
+        enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
           <Link
             key={`${row.index}-block-extrinsic-id`}
             className='hover:text-primaryAccent'
             href={INTERNAL_ROUTES.extrinsics.id.page(network, section, row.original.id)}
           >
-            {`${row.original.block_height}-${row.index}`}
+            {row.original.id}
           </Link>
         ),
       },
       {
         accessorKey: 'hash',
         header: 'Block hash',
-        enableSorting: false,
+        enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
-          <div key={`${row.index}-block-extrinsic-hash`}>{shortString(row.original.hash)}</div>
+          <Link
+            key={`${row.index}-block-extrinsic-id`}
+            className='hover:text-primaryAccent'
+            href={INTERNAL_ROUTES.extrinsics.id.page(network, section, row.original.hash)}
+          >
+            {shortString(row.original.hash)}
+          </Link>
         ),
       },
       {
         accessorKey: 'name',
         header: 'Action',
-        enableSorting: false,
-        cell: ({ row }: Cell<Row>) => (
-          <div key={`${row.index}-block-extrinsic-action`}>
-            {row.original.name.split('.')[1].toUpperCase()}
-          </div>
-        ),
+        enableSorting: true,
+        cell: ({ row }: Cell<Row>) => row.original.name.split('.')[1].toUpperCase(),
       },
       {
-        accessorKey: 'block.timestamp',
+        accessorKey: 'timestamp',
         header: 'Time',
         enableSorting: true,
-        cell: ({ row }: Cell<Row>) => (
-          <div key={`${row.index}-block-extrinsic-action`}>
-            {utcToLocalRelativeTime(row.original.timestamp)}
-          </div>
-        ),
+        cell: ({ row }: Cell<Row>) => utcToLocalRelativeTime(row.original.timestamp),
       },
       {
         accessorKey: 'success',
         header: 'Status',
-        enableSorting: false,
+        enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
           <div
             className='md:flex md:items-center md:justify-start md:pl-5'
@@ -110,6 +145,11 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({ isDesktop = false }) => {
     [network, section],
   )
 
+  const fullDataDownloader = useCallback(
+    () => downloadFullData(apolloClient, QUERY_BLOCK_EXTRINSICS, 'consensus_extrinsics', variables),
+    [apolloClient, variables],
+  )
+
   const totalCount = useMemo(() => (extrinsics ? extrinsics.length : 0), [extrinsics])
   const pageCount = useMemo(
     () => countTablePages(totalCount, pagination.pageSize),
@@ -117,10 +157,10 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({ isDesktop = false }) => {
   )
 
   const noData = useMemo(() => {
-    if (loading) return <Spinner isSmall />
-    if (!data) return <NotFound />
+    if (loading || isLoading(blockDetailsExtrinsic)) return <Spinner isSmall />
+    if (!hasValue(blockDetailsExtrinsic)) return <NotFound />
     return null
-  }, [data, loading])
+  }, [blockDetailsExtrinsic, loading])
 
   useEffect(() => {
     setIsVisible(inView)
@@ -139,6 +179,7 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({ isDesktop = false }) => {
           pageCount={pageCount}
           onPaginationChange={setPagination}
           filename='block-details-extrinsics-list'
+          fullDataDownloader={fullDataDownloader}
         />
       ) : (
         noData

--- a/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
@@ -80,10 +80,10 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({ isDesktop = false }) => {
     'blockDetailsExtrinsic',
   )
 
-  const blockDetailsExtrinsic = useQueryStates((state) => state.consensus.blockDetailsExtrinsic)
+  const consensusEntry = useQueryStates((state) => state.consensus.blockDetailsExtrinsic)
   const extrinsics = useMemo(
-    () => hasValue(blockDetailsExtrinsic) && blockDetailsExtrinsic.value.consensus_extrinsics,
-    [blockDetailsExtrinsic],
+    () => hasValue(consensusEntry) && consensusEntry.value.consensus_extrinsics,
+    [consensusEntry],
   )
 
   const columns = useMemo(
@@ -150,17 +150,23 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({ isDesktop = false }) => {
     [apolloClient, variables],
   )
 
-  const totalCount = useMemo(() => (extrinsics ? extrinsics.length : 0), [extrinsics])
+  const totalCount = useMemo(
+    () =>
+      hasValue(consensusEntry) && consensusEntry.value.consensus_extrinsics_aggregate.aggregate
+        ? consensusEntry.value.consensus_extrinsics_aggregate.aggregate.count
+        : 0,
+    [consensusEntry],
+  )
   const pageCount = useMemo(
     () => countTablePages(totalCount, pagination.pageSize),
     [totalCount, pagination],
   )
 
   const noData = useMemo(() => {
-    if (loading || isLoading(blockDetailsExtrinsic)) return <Spinner isSmall />
-    if (!hasValue(blockDetailsExtrinsic)) return <NotFound />
+    if (loading || isLoading(consensusEntry)) return <Spinner isSmall />
+    if (!hasValue(consensusEntry)) return <NotFound />
     return null
-  }, [blockDetailsExtrinsic, loading])
+  }, [consensusEntry, loading])
 
   useEffect(() => {
     setIsVisible(inView)

--- a/explorer/src/components/Consensus/Block/BlockList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockList.tsx
@@ -136,9 +136,7 @@ export const BlockList: FC = () => {
     TABLE,
   )
 
-  const {
-    consensus: { blocks: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.blocks)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Block/query.ts
+++ b/explorer/src/components/Consensus/Block/query.ts
@@ -60,14 +60,19 @@ export const QUERY_BLOCK_BY_ID = gql`
 `
 
 export const QUERY_BLOCK_EXTRINSICS = gql`
-  query ExtrinsicsByBlockId($blockId: numeric!, $limit: Int!, $offset: Int) {
+  query ExtrinsicsByBlockId(
+    $blockId: numeric!
+    $limit: Int!
+    $offset: Int
+    $orderBy: [consensus_extrinsics_order_by!]
+  ) {
     consensus_extrinsics_aggregate(where: { block_height: { _eq: $blockId } }) {
       aggregate {
         count
       }
     }
     consensus_extrinsics(
-      order_by: { index_in_block: asc }
+      order_by: $orderBy
       limit: $limit
       offset: $offset
       where: { block_height: { _eq: $blockId } }
@@ -84,14 +89,19 @@ export const QUERY_BLOCK_EXTRINSICS = gql`
 `
 
 export const QUERY_BLOCK_EVENTS = gql`
-  query EventsByBlockId($blockId: numeric!, $limit: Int!, $offset: Int) {
+  query EventsByBlockId(
+    $blockId: numeric!
+    $limit: Int!
+    $offset: Int
+    $orderBy: [consensus_events_order_by!]
+  ) {
     consensus_events_aggregate(where: { block_height: { _eq: $blockId } }) {
       aggregate {
         count
       }
     }
     consensus_events(
-      order_by: { index_in_block: asc }
+      order_by: $orderBy
       limit: $limit
       offset: $offset
       where: { block_height: { _eq: $blockId } }

--- a/explorer/src/components/Consensus/Event/Event.tsx
+++ b/explorer/src/components/Consensus/Event/Event.tsx
@@ -28,9 +28,7 @@ export const Event: FC = () => {
     'event',
   )
 
-  const {
-    consensus: { event: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.event)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Event/EventList.tsx
+++ b/explorer/src/components/Consensus/Event/EventList.tsx
@@ -113,9 +113,7 @@ export const EventList: FC = () => {
     TABLE,
   )
 
-  const {
-    consensus: { events: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.events)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Extrinsic/Extrinsic.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/Extrinsic.tsx
@@ -36,9 +36,7 @@ export const Extrinsic: FC = () => {
     'extrinsic',
   )
 
-  const {
-    consensus: { extrinsic: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.extrinsic)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Extrinsic/Extrinsic.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/Extrinsic.tsx
@@ -62,7 +62,10 @@ export const Extrinsic: FC = () => {
         {!loading && extrinsic ? (
           <>
             <ExtrinsicDetailsCard extrinsic={extrinsic} isDesktop={isLargeDesktop} />
-            <ExtrinsicDetailsTab events={extrinsic.events} isDesktop={isDesktop} />
+            <ExtrinsicDetailsTab
+              eventsCount={extrinsic.events_aggregate.aggregate?.count ?? 0}
+              isDesktop={isDesktop}
+            />
           </>
         ) : (
           noData

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsEventList.tsx
@@ -1,36 +1,91 @@
 'use client'
 
+import { useApolloClient } from '@apollo/client'
 import type { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
+import { Spinner } from 'components/common/Spinner'
+import { NotFound } from 'components/layout/NotFound'
 import { PAGE_SIZE } from 'constants/general'
-import { INTERNAL_ROUTES } from 'constants/routes'
-import { ExtrinsicsByIdQuery } from 'gql/graphql'
+import { INTERNAL_ROUTES, Routes } from 'constants/routes'
+import {
+  EventsByExtrinsicIdQuery,
+  EventsByExtrinsicIdQueryVariables,
+  Order_By as OrderBy,
+} from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
+import { useIndexersQuery } from 'hooks/useIndexersQuery'
+import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
-import { FC, useMemo, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { useInView } from 'react-intersection-observer'
+import { hasValue, isLoading, useQueryStates } from 'states/query'
+import { ExtrinsicIdParam } from 'types/app'
 import type { Cell } from 'types/table'
+import { downloadFullData } from 'utils/downloadFullData'
 import { countTablePages } from 'utils/table'
+import { QUERY_EXTRINSIC_EVENTS } from './query'
 
-type Props = {
-  events: NonNullable<ExtrinsicsByIdQuery['consensus_extrinsics'][number]>['events']
-}
+type Row = EventsByExtrinsicIdQuery['consensus_events'][number]
 
-type Row = NonNullable<ExtrinsicsByIdQuery['consensus_extrinsics'][number]>['events'][number]
-
-export const ExtrinsicDetailsEventList: FC<Props> = ({ events }) => {
+export const ExtrinsicDetailsEventList: FC = () => {
+  const { ref, inView } = useInView()
   const { network, section } = useIndexers()
+  const { extrinsicId } = useParams<ExtrinsicIdParam>()
+  const apolloClient = useApolloClient()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,
     pageIndex: 0,
   })
+  const inFocus = useWindowFocus()
+
+  const orderBy = useMemo(
+    () =>
+      sorting && sorting.length > 0
+        ? sorting[0].id.endsWith('aggregate')
+          ? { [sorting[0].id]: sorting[0].desc ? { count: OrderBy.Desc } : { count: OrderBy.Asc } }
+          : { [sorting[0].id]: sorting[0].desc ? OrderBy.Desc : OrderBy.Asc }
+        : // eslint-disable-next-line camelcase
+          { sort_id: OrderBy.Desc },
+    [sorting],
+  )
+
+  const variables = useMemo(
+    () => ({
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex > 0 ? pagination.pageIndex * pagination.pageSize : undefined,
+      orderBy,
+      extrinsicId: extrinsicId as string,
+    }),
+    [pagination.pageSize, pagination.pageIndex, orderBy, extrinsicId],
+  )
+
+  const { loading, setIsVisible } = useIndexersQuery<
+    EventsByExtrinsicIdQuery,
+    EventsByExtrinsicIdQueryVariables
+  >(
+    QUERY_EXTRINSIC_EVENTS,
+    {
+      variables,
+      skip: !inFocus,
+    },
+    Routes.consensus,
+    'extrinsicDetailsEvent',
+  )
+
+  const extrinsicDetailsEvent = useQueryStates((state) => state.consensus.extrinsicDetailsEvent)
+  const events = useMemo(
+    () => hasValue(extrinsicDetailsEvent) && extrinsicDetailsEvent.value.consensus_events,
+    [extrinsicDetailsEvent],
+  )
 
   const columns = useMemo(
     () => [
       {
-        accessorKey: 'id',
+        accessorKey: 'sort_id',
         header: 'Event Id',
-        enableSorting: false,
+        enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
           <Link
             key={`${row.index}-extrinsic-event-id`}
@@ -50,9 +105,9 @@ export const ExtrinsicDetailsEventList: FC<Props> = ({ events }) => {
         ),
       },
       {
-        accessorKey: 'action',
+        accessorKey: 'name',
         header: 'Action',
-        enableSorting: false,
+        enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
           <div key={`${row.index}-extrinsic-event-action`}>{row.original.name.split('.')[1]}</div>
         ),
@@ -60,7 +115,7 @@ export const ExtrinsicDetailsEventList: FC<Props> = ({ events }) => {
       {
         accessorKey: 'phase',
         header: 'Type',
-        enableSorting: false,
+        enableSorting: true,
         cell: ({ row }: Cell<Row>) => (
           <div key={`${row.index}-extrinsic-event-phase`}>{row.original.phase}</div>
         ),
@@ -69,23 +124,45 @@ export const ExtrinsicDetailsEventList: FC<Props> = ({ events }) => {
     [network, section],
   )
 
+  const fullDataDownloader = useCallback(
+    () => downloadFullData(apolloClient, QUERY_EXTRINSIC_EVENTS, 'consensus_events', variables),
+    [apolloClient, variables],
+  )
+
   const totalCount = useMemo(() => (events ? events.length : 0), [events])
   const pageCount = useMemo(
     () => countTablePages(totalCount, pagination.pageSize),
     [totalCount, pagination],
   )
 
+  const noData = useMemo(() => {
+    if (loading || isLoading(extrinsicDetailsEvent)) return <Spinner isSmall />
+    if (!hasValue(extrinsicDetailsEvent)) return <NotFound />
+    return null
+  }, [loading, extrinsicDetailsEvent])
+
+  useEffect(() => {
+    setIsVisible(inView)
+  }, [inView, setIsVisible])
+
   return (
-    <SortedTable
-      data={events}
-      columns={columns}
-      showNavigation={true}
-      sorting={sorting}
-      onSortingChange={setSorting}
-      pagination={pagination}
-      pageCount={pageCount}
-      onPaginationChange={setPagination}
-      filename='extrinsic-details-event-list'
-    />
+    <div className='mt-5 flex w-full flex-col space-y-4 sm:mt-0' ref={ref}>
+      {!loading && events ? (
+        <SortedTable
+          data={events}
+          columns={columns}
+          showNavigation={true}
+          sorting={sorting}
+          onSortingChange={setSorting}
+          pagination={pagination}
+          pageCount={pageCount}
+          onPaginationChange={setPagination}
+          filename='extrinsic-details-event-list'
+          fullDataDownloader={fullDataDownloader}
+        />
+      ) : (
+        noData
+      )}
+    </div>
   )
 }

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsTab.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsTab.tsx
@@ -1,19 +1,18 @@
 import { PageTabs } from 'components/common/PageTabs'
 import { Tab } from 'components/common/Tabs'
-import { ExtrinsicsByIdQuery } from 'gql/graphql'
 import { FC } from 'react'
 import { ExtrinsicDetailsEventList } from './ExtrinsicDetailsEventList'
 
 type Props = {
-  events: NonNullable<ExtrinsicsByIdQuery['consensus_extrinsics'][number]>['events']
+  eventsCount: number
   isDesktop?: boolean
 }
 
-export const ExtrinsicDetailsTab: FC<Props> = ({ events, isDesktop = false }) => {
+export const ExtrinsicDetailsTab: FC<Props> = ({ eventsCount, isDesktop = false }) => {
   return (
     <PageTabs isDesktop={isDesktop}>
-      <Tab title={`Events (${events.length})`}>
-        <ExtrinsicDetailsEventList events={events} />
+      <Tab title={`Events (${eventsCount})`}>
+        <ExtrinsicDetailsEventList />
       </Tab>
     </PageTabs>
   )

--- a/explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx
@@ -112,9 +112,7 @@ export const ExtrinsicList: FC = () => {
     TABLE,
   )
 
-  const {
-    consensus: { extrinsics: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.extrinsics)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Extrinsic/query.ts
+++ b/explorer/src/components/Consensus/Extrinsic/query.ts
@@ -51,15 +51,40 @@ export const QUERY_EXTRINSIC_BY_ID = gql`
       tip
       args
       signer
-      events(limit: 10) {
-        id
-        phase
-        timestamp
-        name
-        args
-        extrinsic_id
+      events_aggregate {
+        aggregate {
+          count
+        }
       }
       name
+    }
+  }
+`
+
+export const QUERY_EXTRINSIC_EVENTS = gql`
+  query EventsByExtrinsicId(
+    $extrinsicId: String!
+    $limit: Int!
+    $offset: Int
+    $orderBy: [consensus_events_order_by!]
+  ) {
+    consensus_events_aggregate(where: { extrinsic_id: { _eq: $extrinsicId } }) {
+      aggregate {
+        count
+      }
+    }
+    consensus_events(
+      order_by: $orderBy
+      limit: $limit
+      offset: $offset
+      where: { extrinsic_id: { _eq: $extrinsicId } }
+    ) {
+      id
+      name
+      phase
+      index_in_block
+      block_height
+      extrinsic_id
     }
   }
 `

--- a/explorer/src/components/Consensus/Home/index.tsx
+++ b/explorer/src/components/Consensus/Home/index.tsx
@@ -30,9 +30,7 @@ export const Home: FC = () => {
     'home',
   )
 
-  const {
-    consensus: { home: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.home)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Log/Log.tsx
+++ b/explorer/src/components/Consensus/Log/Log.tsx
@@ -29,9 +29,7 @@ export const Log: FC = () => {
     'log',
   )
 
-  const {
-    consensus: { log: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.log)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Consensus/Log/LogList.tsx
+++ b/explorer/src/components/Consensus/Log/LogList.tsx
@@ -108,9 +108,7 @@ export const LogList: FC = () => {
     TABLE,
   )
 
-  const {
-    consensus: { logs: consensusEntry },
-  } = useQueryStates()
+  const consensusEntry = useQueryStates((state) => state.consensus.logs)
 
   const data = useMemo(() => {
     if (hasValue(consensusEntry)) return consensusEntry.value

--- a/explorer/src/components/Domain/Domain.tsx
+++ b/explorer/src/components/Domain/Domain.tsx
@@ -33,9 +33,7 @@ export const Domain: FC = () => {
     'domain',
   )
 
-  const {
-    domains: { domain },
-  } = useQueryStates()
+  const domain = useQueryStates((state) => state.domains.domain)
 
   const domainDetails = useMemo(
     () => hasValue(domain) && domain.value.staking_domains_by_pk,

--- a/explorer/src/components/Domain/DomainsList.tsx
+++ b/explorer/src/components/Domain/DomainsList.tsx
@@ -378,9 +378,7 @@ export const DomainsList: FC = () => {
     TABLE,
   )
 
-  const {
-    domains: { domains },
-  } = useQueryStates()
+  const domains = useQueryStates((state) => state.domains.domains)
 
   const fullDataDownloader = useCallback(
     () =>

--- a/explorer/src/components/Staking/Operator.tsx
+++ b/explorer/src/components/Staking/Operator.tsx
@@ -36,9 +36,7 @@ export const Operator: FC = () => {
     'operator',
   )
 
-  const {
-    staking: { operator },
-  } = useQueryStates()
+  const operator = useQueryStates((state) => state.staking.operator)
 
   const operatorDetails = useMemo(
     () => hasValue(operator) && operator.value.staking_operators_by_pk,

--- a/explorer/src/components/Staking/OperatorNominatorTable.tsx
+++ b/explorer/src/components/Staking/OperatorNominatorTable.tsx
@@ -188,9 +188,7 @@ export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
     'operatorNominators',
   )
 
-  const {
-    staking: { operatorNominators },
-  } = useQueryStates()
+  const operatorNominators = useQueryStates((state) => state.staking.operatorNominators)
 
   const nominators = useMemo(
     () => (hasValue(operatorNominators) ? operatorNominators.value.staking_nominators : []),

--- a/explorer/src/components/Staking/OperatorsList.tsx
+++ b/explorer/src/components/Staking/OperatorsList.tsx
@@ -543,9 +543,7 @@ export const OperatorsList: FC<OperatorsListProps> = ({ domainId }) => {
     TABLE,
   )
 
-  const {
-    staking: { operators },
-  } = useQueryStates()
+  const operators = useQueryStates((state) => state.staking.operators)
 
   const fullDataDownloader = useCallback(
     () =>

--- a/explorer/src/components/WalletSideKick/Actions/ClaimStakingToken.tsx
+++ b/explorer/src/components/WalletSideKick/Actions/ClaimStakingToken.tsx
@@ -34,9 +34,7 @@ export const ClaimStakingToken: FC = () => {
     'claim',
   )
 
-  const {
-    walletSidekick: { claim },
-  } = useQueryStates()
+  const claim = useQueryStates((state) => state.walletSidekick.claim)
 
   const handleClaimOperatorDisbursement = useCallback(async () => {
     setClaimError(null)

--- a/explorer/src/components/WalletSideKick/LastExtrinsics.tsx
+++ b/explorer/src/components/WalletSideKick/LastExtrinsics.tsx
@@ -55,9 +55,7 @@ export const LastExtrinsics: FC<LastExtrinsicsProps> = ({ subspaceAccount }) => 
     'lastExtrinsics',
   )
 
-  const {
-    walletSidekick: { lastExtrinsics },
-  } = useQueryStates()
+  const lastExtrinsics = useQueryStates((state) => state.walletSidekick.lastExtrinsics)
 
   const extrinsics = useMemo(
     () => hasValue(lastExtrinsics) && lastExtrinsics.value.extrinsics,

--- a/explorer/src/components/WalletSideKick/Leaderboard.tsx
+++ b/explorer/src/components/WalletSideKick/Leaderboard.tsx
@@ -48,9 +48,7 @@ export const useLeaderboard = (subspaceAccount: string) => {
     'leaderboard',
   )
 
-  const {
-    walletSidekick: { leaderboard },
-  } = useQueryStates()
+  const leaderboard = useQueryStates((state) => state.walletSidekick.leaderboard)
 
   const loading = useMemo(() => isLoading(leaderboard), [leaderboard])
   const data = useMemo(() => hasValue(leaderboard) && leaderboard.value, [leaderboard])

--- a/explorer/src/components/WalletSideKick/StakingSummary.tsx
+++ b/explorer/src/components/WalletSideKick/StakingSummary.tsx
@@ -46,9 +46,7 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
     'stakingSummary',
   )
 
-  const {
-    walletSidekick: { stakingSummary },
-  } = useQueryStates()
+  const stakingSummary = useQueryStates((state) => state.walletSidekick.stakingSummary)
 
   const totalOperatorCount = useMemo(
     () =>

--- a/explorer/src/components/common/ErrorFallback/index.tsx
+++ b/explorer/src/components/common/ErrorFallback/index.tsx
@@ -1,6 +1,5 @@
 import { ArrowButton } from 'components/common/ArrowButton'
-
-import { EXTERNAL_ROUTES } from '@/constants/routes'
+import { EXTERNAL_ROUTES } from 'constants/routes'
 import AstronautImage from './AstronautImage'
 
 interface Props {

--- a/explorer/src/hooks/useIndexersQuery.ts
+++ b/explorer/src/hooks/useIndexersQuery.ts
@@ -23,7 +23,9 @@ export const useIndexersQuery = <TData, TVariables extends OperationVariables>(
   isVisible: boolean
   setIsVisible: (isVisible: boolean) => void
 } => {
-  const { setIsLoading, setValue, setError } = useQueryStates()
+  const setIsLoading = useQueryStates((state) => state.setIsLoading)
+  const setValue = useQueryStates((state) => state.setValue)
+  const setError = useQueryStates((state) => state.setError)
 
   const [_isVisible, _setIsVisible] = useState<{ [key: string]: boolean }>(
     section && component ? { [`${section}.${component}`]: true } : { '0': true },

--- a/explorer/src/states/query.ts
+++ b/explorer/src/states/query.ts
@@ -50,6 +50,8 @@ interface ExplorerQueryState {
 
     blockDetailsExtrinsic: QueryState<GqlT.ExtrinsicsByBlockIdQuery>
     blockDetailsEvent: QueryState<GqlT.EventsByBlockIdQuery>
+
+    extrinsicDetailsEvent: QueryState<GqlT.EventsByExtrinsicIdQuery>
   }
   [Routes.staking]: {
     operators: QueryState<GqlT.OperatorsListQuery>
@@ -109,6 +111,8 @@ const initialState: ExplorerQueryState = {
 
     blockDetailsExtrinsic: initialized,
     blockDetailsEvent: initialized,
+
+    extrinsicDetailsEvent: initialized,
   },
   staking: {
     operators: initialized,

--- a/explorer/src/states/query.ts
+++ b/explorer/src/states/query.ts
@@ -47,6 +47,8 @@ interface ExplorerQueryState {
     accountPreviousReward: QueryState<GqlT.AllRewardForAccountByIdQuery>
     accountRewardGraph: QueryState<GqlT.LatestRewardsWeekQuery>
     accountReward: QueryState<GqlT.RewardsListQuery>
+    accountTransfers: QueryState<GqlT.TransfersByAccountIdQuery>
+    accountBalanceHistory: QueryState<GqlT.BalanceHistoryByAccountIdQuery>
 
     blockDetailsExtrinsic: QueryState<GqlT.ExtrinsicsByBlockIdQuery>
     blockDetailsEvent: QueryState<GqlT.EventsByBlockIdQuery>
@@ -108,6 +110,8 @@ const initialState: ExplorerQueryState = {
     accountPreviousReward: initialized,
     accountRewardGraph: initialized,
     accountReward: initialized,
+    accountTransfers: initialized,
+    accountBalanceHistory: initialized,
 
     blockDetailsExtrinsic: initialized,
     blockDetailsEvent: initialized,

--- a/explorer/src/utils/sort.ts
+++ b/explorer/src/utils/sort.ts
@@ -1,4 +1,0 @@
-import type { SortingState } from '@tanstack/react-table'
-
-export const sort = (sorting: SortingState, init: string): string =>
-  sorting.map((s) => `${s.id}_${s.desc ? 'DESC' : 'ASC'}`).join(',') || init


### PR DESCRIPTION
### **User description**
## Fix details page sub-list, improve sorting and caching

- When on a detail page (Account, Block and Extrinsic) separate the query generating the children list in it's own query & logic, allowing for pagination, sorting and such
- Improve use of zustand query state to make sure we cache the last result, this way if one query fail, we still have the last result to show, while re re-try
- Improve the use of zustand to not deconstruct and potentially generate multiple re-render if other value get updated


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced GraphQL queries to support sorting and aggregation, improving data retrieval efficiency.
- Simplified state management across multiple components by refactoring `useQueryStates` usage.
- Improved sorting and pagination functionalities in various lists and tables.
- Added new query types and states to support detailed data fetching and management.
- Fixed import path in `ErrorFallback` component.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>35 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>graphql.ts</strong><dd><code>Enhance GraphQL queries with sorting and aggregation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/gql/graphql.ts

<li>Added <code>sort_id</code> to <code>ExtrinsicsByAccountIdQuery</code>.<br> <li> Introduced <code>orderBy</code> parameter to <code>ExtrinsicsByBlockIdQueryVariables</code> and <br><code>EventsByBlockIdQueryVariables</code>.<br> <li> Modified <code>ExtrinsicsByIdQuery</code> to include <code>events_aggregate</code>.<br> <li> Added new query type <code>EventsByExtrinsicIdQuery</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-bc0e46e46459f8be09a193e520663a980b0e3512600117b0db7772f0d66a1290">+14/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Account.tsx</strong><dd><code>Simplify state management in Account component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/Account.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-c1e1c97b2238837cd4425fa878430ea87682d1e57d3f70d0c394e1413ba0a0a8">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountExtrinsicList.tsx</strong><dd><code>Improve sorting and state management in AccountExtrinsicList</code></dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountExtrinsicList.tsx

<li>Updated sorting logic to use <code>sort_id</code>.<br> <li> Improved data fetching and state management.<br> <li> Enhanced pagination and sorting functionalities.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-bda77c8265dae0962030dcf3d0533e2bf7965a6829d8ff37f77c4bdf3b7f9d9e">+27/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountList.tsx</strong><dd><code>Simplify state management in AccountList component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountList.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-346bc0b0c8f34267532556d5d327927b0a1faae0236a743659b556e75727d905">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountRewardGraph.tsx</strong><dd><code>Simplify state management in AccountRewardGraph component</code></dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountRewardGraph.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-0ad82ac2d09dab5ac055476b5bd391ae9100dd6052ecdbda6be3d18098fd10a0">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountRewardList.tsx</strong><dd><code>Enhance state management in AccountRewardList</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountRewardList.tsx

<li>Simplified <code>useQueryStates</code> usage for <code>consensusEntry</code>.<br> <li> Improved data fetching and state management.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-f0dd9aa976a027f4dafc25bbf6042592aa1b4612ee8f3e6c7e567e6a537a57b1">+16/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AccountTransfersList.tsx</strong><dd><code>Enhance state management in AccountTransfersList</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/AccountTransfersList.tsx

<li>Simplified <code>useQueryStates</code> usage for <code>consensusEntry</code>.<br> <li> Improved data fetching and state management.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-afd94db3a36e317fce480fbaece463ae43c37fbb01aa8150fc386a52774cd5de">+29/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BalanceHistory.tsx</strong><dd><code>Enhance state management in BalanceHistory component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/BalanceHistory.tsx

<li>Simplified <code>useQueryStates</code> usage for <code>consensusEntry</code>.<br> <li> Improved data fetching and state management.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-4b87a20823c6d33f6284ae35ca4d5bb9af5def72d42f8e3dfa3a26661ef5605b">+32/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query.ts</strong><dd><code>Add sorting capability to account extrinsics query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Account/query.ts

- Added `sort_id` to `QUERY_ACCOUNT_EXTRINSICS`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-34680083159c0630ee243dda507b8ca8383c08a4d8ed0aedfb2617a69bf2f08d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Block.tsx</strong><dd><code>Simplify state management in Block component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Block/Block.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-0b93eb60dd21e6a4674d5355741ff1a63c427c393bec4976083125f3a0c02392">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BlockDetailsEventList.tsx</strong><dd><code>Enhance sorting and state management in BlockDetailsEventList</code></dd></summary>
<hr>

explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx

<li>Added sorting functionality using <code>sort_id</code>.<br> <li> Improved data fetching and state management.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-e1426e45a71a8875edc2ac7f418ff13f8f145db23ddf66017ab20fef2c4c20dd">+48/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BlockDetailsExtrinsicList.tsx</strong><dd><code>Enhance sorting and state management in BlockDetailsExtrinsicList</code></dd></summary>
<hr>

explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx

<li>Added sorting functionality using <code>sort_id</code>.<br> <li> Improved data fetching and state management.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-cf160cd96f9bb39cf22de950ba70d9a4299942cb702bdd52860cb47d7fc3fe3c">+81/-34</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BlockList.tsx</strong><dd><code>Simplify state management in BlockList component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Block/BlockList.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-1fd78c7164fd845bbcab711583acf55daec431126e9bd31eb65784de24fb7e83">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query.ts</strong><dd><code>Add sorting capability to block queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Block/query.ts

<li>Added <code>orderBy</code> parameter to <code>QUERY_BLOCK_EXTRINSICS</code> and <br><code>QUERY_BLOCK_EVENTS</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-8d59912a1264d9110808f01dba8e093d31812fe3e2503daf4659f6889db06f29">+14/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Event.tsx</strong><dd><code>Simplify state management in Event component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Event/Event.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-086b8bb079b89e39798cc094bc13624c81d8a82e70f07586ccb4d5033910fefb">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EventList.tsx</strong><dd><code>Simplify state management in EventList component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Event/EventList.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-f9668fdac9338cc529d6eae04188739a10dc176154e3eebc20ed101e4bb3e325">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Extrinsic.tsx</strong><dd><code>Simplify state management and enhance ExtrinsicDetailsTab</code></dd></summary>
<hr>

explorer/src/components/Consensus/Extrinsic/Extrinsic.tsx

<li>Simplified <code>useQueryStates</code> usage for <code>consensusEntry</code>.<br> <li> Updated <code>ExtrinsicDetailsTab</code> to use <code>eventsCount</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-077acec6dc825531a5cacb0e381a4ea4181c6e39f0043b9f6dff6c97fc3067e1">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExtrinsicDetailsEventList.tsx</strong><dd><code>Enhance sorting and state management in ExtrinsicDetailsEventList</code></dd></summary>
<hr>

explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsEventList.tsx

<li>Added sorting functionality using <code>sort_id</code>.<br> <li> Improved data fetching and state management.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-ed7f182457edac2d2c47cfdf6253fddb71e074df5096e298b837c8f4b7d5c563">+102/-25</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExtrinsicDetailsTab.tsx</strong><dd><code>Update ExtrinsicDetailsTab to use event count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Extrinsic/ExtrinsicDetailsTab.tsx

- Updated to use `eventsCount` instead of `events`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-2fbce8ef6688e7d9cef3e3c1b2ccc6b930c10d76e655c20cc842d5928d218abd">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExtrinsicList.tsx</strong><dd><code>Simplify state management in ExtrinsicList component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Extrinsic/ExtrinsicList.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-6d5f265eac35112e020c6d81f064f33927fe8b039164a62e5fc934912a508922">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query.ts</strong><dd><code>Add query for fetching events by extrinsic ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Extrinsic/query.ts

<li>Added <code>QUERY_EXTRINSIC_EVENTS</code> for fetching events by extrinsic ID.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-cc538235842b039e08052a4bb71ccd055aeb6ec752f1a864a257e5f86a998e12">+32/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Simplify state management in Home component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Home/index.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-44a87c22bdec9561da2c1de825d10ca26b5aa0b3bfd8e4cc0cbec2d71e81c610">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Log.tsx</strong><dd><code>Simplify state management in Log component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Log/Log.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-9d3498482f508d7979a7780456990bbeecd9d9cecbf6a9a545ff27e746822167">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LogList.tsx</strong><dd><code>Simplify state management in LogList component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Consensus/Log/LogList.tsx

- Simplified `useQueryStates` usage for `consensusEntry`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-46354d35324248c092295ba505dc0f1455ceec2861cea0cd1f71fef8bc49b221">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Domain.tsx</strong><dd><code>Simplify state management in Domain component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Domain/Domain.tsx

- Simplified `useQueryStates` usage for `domain`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-b75731c5b514be88226408efd637bfe34f26be6d0b2aaa46024a32411eeda3c6">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DomainsList.tsx</strong><dd><code>Simplify state management in DomainsList component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Domain/DomainsList.tsx

- Simplified `useQueryStates` usage for `domains`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-98fd46c0bc6c3c1ba003d25e42c7342b5cd15295d7afd048f50fa58a8bb2f9f4">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Operator.tsx</strong><dd><code>Simplify state management in Operator component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Staking/Operator.tsx

- Simplified `useQueryStates` usage for `operator`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-9a1074ddc60bbd99c6bc34c279c3dc2ee4f00571645b50b6e683cf908ac1443e">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OperatorNominatorTable.tsx</strong><dd><code>Simplify state management in OperatorNominatorTable component</code></dd></summary>
<hr>

explorer/src/components/Staking/OperatorNominatorTable.tsx

- Simplified `useQueryStates` usage for `operatorNominators`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-1cc906aaa845e6e8da1214d968027b78682f0313071a2fa206797b4a8ae1defe">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OperatorsList.tsx</strong><dd><code>Simplify state management in OperatorsList component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Staking/OperatorsList.tsx

- Simplified `useQueryStates` usage for `operators`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-2f63461d6975c034ac8b70b9ccf2030ca14290ecc622680b0d37d6ad4cd04711">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClaimStakingToken.tsx</strong><dd><code>Simplify state management in ClaimStakingToken component</code>&nbsp; </dd></summary>
<hr>

explorer/src/components/WalletSideKick/Actions/ClaimStakingToken.tsx

- Simplified `useQueryStates` usage for `claim`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-2919efd1dd28514e22d525bf31c809da4220f174f838606bb9f09292eb0e7e40">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LastExtrinsics.tsx</strong><dd><code>Simplify state management in LastExtrinsics component</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/WalletSideKick/LastExtrinsics.tsx

- Simplified `useQueryStates` usage for `lastExtrinsics`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-1ea921417daf04e3f27971fff139d201a2bea1a271add0a81067a12aad9f876a">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Leaderboard.tsx</strong><dd><code>Simplify state management in Leaderboard component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/WalletSideKick/Leaderboard.tsx

- Simplified `useQueryStates` usage for `leaderboard`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-51516aae14edfdcaf941590172bb34610ddf4b07bdfbfd237b57163426066662">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StakingSummary.tsx</strong><dd><code>Simplify state management in StakingSummary component</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/WalletSideKick/StakingSummary.tsx

- Simplified `useQueryStates` usage for `stakingSummary`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-c41cf12ddd3b475d1a986b4d24f1f3e992f16b7d86e1932a21d9846d1f301a38">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useIndexersQuery.ts</strong><dd><code>Refactor useIndexersQuery to use state selectors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/hooks/useIndexersQuery.ts

- Refactored `useQueryStates` to use individual state selectors.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-9d4a9bc9400a046e2f9b3da6ff03687f0ff1f3504b2843510a82126e54da4345">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query.ts</strong><dd><code>Add new query states for enhanced data management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/states/query.ts

<li>Added new query states for <code>accountTransfers</code>, <code>accountBalanceHistory</code>, <br>and <code>extrinsicDetailsEvent</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-e891278e1530dc7a2a77e5f50264d2df415cacd6aabe8dd09a7b4ffdd451523c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Fix import path in ErrorFallback component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/common/ErrorFallback/index.tsx

- Fixed import path for `EXTERNAL_ROUTES`.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-569b44f0f60fb681e6e46bf15b3a40df3e5c1a6b943ed6be3ca8b75c5a6083f5">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>sort.ts</strong><dd><code>Remove unused sorting utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/utils/sort.ts

- Removed unused sorting utility function.



</details>


  </td>
  <td><a href="https://github.com/autonomys/astral/pull/992/files#diff-9bee7f201bba27e046f8584dfe23cf6a4c8a8f791864a473a69793d6cab163e6">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information