### PR TITLE
fix _id to custom_column_names uuid

### DIFF
--- a/indexers/db/metadata/databases/default/tables/files_chunks.yaml
+++ b/indexers/db/metadata/databases/default/tables/files_chunks.yaml
@@ -1,6 +1,13 @@
 table:
   name: chunks
   schema: files
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 object_relationships:
   - name: cid
     using:

--- a/indexers/db/metadata/databases/default/tables/files_cids.yaml
+++ b/indexers/db/metadata/databases/default/tables/files_cids.yaml
@@ -1,6 +1,13 @@
 table:
   name: cids
   schema: files
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 object_relationships:
   - name: chunk
     using:

--- a/indexers/db/metadata/databases/default/tables/files_file_cids.yaml
+++ b/indexers/db/metadata/databases/default/tables/files_file_cids.yaml
@@ -1,6 +1,13 @@
 table:
   name: file_cids
   schema: files
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 object_relationships:
   - name: chunk
     using:

--- a/indexers/db/metadata/databases/default/tables/files_files.yaml
+++ b/indexers/db/metadata/databases/default/tables/files_files.yaml
@@ -1,6 +1,13 @@
 table:
   name: files
   schema: files
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 object_relationships:
   - name: chunk
     using:

--- a/indexers/db/metadata/databases/default/tables/files_folder_cids.yaml
+++ b/indexers/db/metadata/databases/default/tables/files_folder_cids.yaml
@@ -1,6 +1,13 @@
 table:
   name: folder_cids
   schema: files
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 object_relationships:
   - name: chunk
     using:

--- a/indexers/db/metadata/databases/default/tables/files_folders.yaml
+++ b/indexers/db/metadata/databases/default/tables/files_folders.yaml
@@ -1,6 +1,13 @@
 table:
   name: folders
   schema: files
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 object_relationships:
   - name: chunk
     using:

--- a/indexers/db/metadata/databases/default/tables/files_metadata.yaml
+++ b/indexers/db/metadata/databases/default/tables/files_metadata.yaml
@@ -1,6 +1,13 @@
 table:
   name: metadata
   schema: files
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 object_relationships:
   - name: chunk
     using:

--- a/indexers/db/metadata/databases/default/tables/files_metadata_cids.yaml
+++ b/indexers/db/metadata/databases/default/tables/files_metadata_cids.yaml
@@ -1,6 +1,13 @@
 table:
   name: metadata_cids
   schema: files
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 object_relationships:
   - name: chunk
     using:


### PR DESCRIPTION
## fix _id to custom_column_names uuid

This is to avoid the collision of `id` and `_id` in codegen