### PR TITLE
Try blocking bots at the edge

### DIFF
--- a/explorer/netlify.toml
+++ b/explorer/netlify.toml
@@ -1,0 +1,13 @@
+[[edge_functions]]
+path = "/*"
+function = "blockBots"
+
+[[redirects]]
+from = "/wp-*"
+to = "/404"
+status = 403
+
+[[redirects]]
+from = "/xmlrpc.php"
+to = "/404"
+status = 403

--- a/explorer/netlify/edge-functions/blockBots.ts
+++ b/explorer/netlify/edge-functions/blockBots.ts
@@ -1,0 +1,19 @@
+import type { Config } from '@netlify/edge-functions'
+
+export default async function () {
+  const html404 =
+    '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>404 Not Found</h1></body></html>'
+
+  return new Response(html404, {
+    status: 404,
+    headers: {
+      'Content-Type': 'text/html',
+      'netlify-cdn-cache-control': 'durable, immutable, max-age=31536000, public',
+    },
+  })
+}
+
+export const config: Config = {
+  cache: 'manual',
+  pattern: '^.*((wp-admin|wp-content|wp-includes|\\.htaccess).*|\\.[Pp][Hh][Pp])$',
+}

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -36,6 +36,7 @@
     "@headlessui/react": "^1.7.18",
     "@headlessui/tailwindcss": "^0.2.0",
     "@heroicons/react": "^2.1.1",
+    "@netlify/edge-functions": "^2.11.1",
     "@next/third-parties": "^14.2.3",
     "@nivo/core": "^0.84.0",
     "@nivo/line": "^0.84.0",

--- a/explorer/yarn.lock
+++ b/explorer/yarn.lock
@@ -1962,6 +1962,11 @@
   resolved "https://registry.yarnpkg.com/@metamask/types/-/types-1.1.0.tgz#9bd14b33427932833c50c9187298804a18c2e025"
   integrity sha512-EEV/GjlYkOSfSPnYXfOosxa3TqYtIW3fhg6jdw+cok/OhMgNn4wCfbENFqjytrHMU2f7ZKtBAvtiP5V8H44sSw==
 
+"@netlify/edge-functions@^2.11.1":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@netlify/edge-functions/-/edge-functions-2.11.1.tgz#638decdda617ce2b92a97cb4140460b82263962f"
+  integrity sha512-pyQOTZ8a+ge5lZlE+H/UAHyuqQqtL5gE0pXrHT9mOykr3YQqnkB2hZMtx12odatZ87gHg4EA+UPyMZUbLfnXvw==
+
 "@next/env@14.1.3":
   version "14.1.3"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-14.1.3.tgz#73007b64d487bbb95ed83145195f734fc1182d10"


### PR DESCRIPTION
## Try blocking bots at the edge

Netlify give us very poor details on what all these function call are, and I see that even the paid analytics is very limited in what information it give, but it seems like we have A LOT of function call and this increases our billing.

I'm assuming a large % is due to bot and scrapper trying to fetch wp route that don't exist, and us processing these as true 404 on our normal route, so I'm trying to add a catcher at the edge since edge function have a much higher limit and extra are much cheaper