### PR TITLE
Improve sub query syncing speed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,6 +226,7 @@ services:
       - --workers=4
       - --unsafe
       - --batch-size=250
+      - --scale-batch-size
       - --unfinalized-blocks=true
       - --disable-historical=false
       - --port 3001
@@ -262,7 +263,8 @@ services:
       - -f=/${NETWORK_ID}/leaderboard
       - --db-schema=leaderboard
       - --workers=1
-      - --batch-size=15
+      - --batch-size=100
+      - --scale-batch-size
       - --unfinalized-blocks=true
       - --disable-historical=false
       - --port 3002
@@ -300,7 +302,8 @@ services:
       - --db-schema=staking
       - --workers=1
       - --unsafe
-      - --batch-size=15
+      - --batch-size=100
+      - --scale-batch-size
       - --disable-historical=true
       - --port 3003
     healthcheck:
@@ -334,7 +337,8 @@ services:
       - --db-schema=files
       - --workers=1
       - --unsafe
-      - --batch-size=15
+      - --batch-size=25
+      - --scale-batch-size
       - --unfinalized-blocks=true
       - --disable-historical=false
       - --port 3004

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,6 +230,7 @@ services:
       - --unfinalized-blocks=true
       - --disable-historical=false
       - --port 3001
+      #  - --profiler
     healthcheck:
       test: ["CMD", "curl", "-f", "http://consensus_subquery_node:3001/ready"]
       interval: 3s
@@ -268,6 +269,7 @@ services:
       - --unfinalized-blocks=true
       - --disable-historical=false
       - --port 3002
+      #  - --profiler
     healthcheck:
       test: ["CMD", "curl", "-f", "http://leaderboard_subquery_node:3002/ready"]
       interval: 3s
@@ -306,6 +308,7 @@ services:
       - --scale-batch-size
       - --disable-historical=true
       - --port 3003
+      #  - --profiler
     healthcheck:
       test: ["CMD", "curl", "-f", "http://staking_subquery_node:3003/ready"]
       interval: 3s
@@ -342,6 +345,7 @@ services:
       - --unfinalized-blocks=true
       - --disable-historical=false
       - --port 3004
+      #  - --profiler
     healthcheck:
       test: ["CMD", "curl", "-f", "http://files_subquery_node:3004/ready"]
       interval: 3s


### PR DESCRIPTION
## Improve Sub Query syncing speed

- Add `--scale-batch-size` to scale the memory of the subquery node according to the batch size. Even if we set it to query 250 blocks per batch, the engine does not have enough memory to store that many blocks.
- Add commented out `--profiler` as a way to remember when working on optimization and when modifying the logic, turning this flag on gives us clear details of the speed impact of the logic per handler
- Increase the batch size of the leaderboard and staking indexers

These changes seem to give us 12 to 20x improvements in sync time 🚀 
![image](https://github.com/user-attachments/assets/1607be08-bd43-4357-b873-e7080a1764d9)
100K blocks/h while running other indexers in parallels, I'll take it!