### PR TITLE
Switch account details tabs priority

### DIFF
--- a/explorer/src/components/Consensus/Account/Account.tsx
+++ b/explorer/src/components/Consensus/Account/Account.tsx
@@ -79,14 +79,14 @@ export const Account: FC = () => {
               <AccountRewardsHistory isDesktop={isDesktop} rewards={rewards} />
             </div>
             <PageTabs isDesktop={isDesktop}>
+              <Tab title='Balance History'>
+                <BalanceHistory accountId={accountId} />
+              </Tab>
               <Tab title='Extrinsic List'>
                 <AccountExtrinsicList accountId={accountId} />
               </Tab>
               <Tab title='Transfers'>
                 <AccountTransfersList accountId={accountId} />
-              </Tab>
-              <Tab title='Balance History'>
-                <BalanceHistory accountId={accountId} />
               </Tab>
             </PageTabs>
           </>


### PR DESCRIPTION
## Switch account details tabs priority

Simple PR to switch the tabs order on account details to show balance history before extrinsic list