### PR TITLE
Disable indexer workflow

### DIFF
--- a/.github/workflows/gh-deploy-subql.yml
+++ b/.github/workflows/gh-deploy-subql.yml
@@ -1,86 +1,86 @@
-name: Deploy Subql Green (staging)
+# name: Deploy Subql Green (staging)
 
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - "indexers/**"
-env:
-  DOCKER_HOST: ssh://${{ secrets.SSH_USER }}@${{ secrets.SUBQL_HOST }}
-  DEPLOY_PATH: /home/${{ secrets.SSH_USER }}/astral
-  BRANCH_NAME: ${{ github.ref_name }}
+# on:
+#   push:
+#     branches:
+#       - main
+#     paths:
+#       - "indexers/**"
+# env:
+#   DOCKER_HOST: ssh://${{ secrets.SSH_USER }}@${{ secrets.SUBQL_HOST }}
+#   DEPLOY_PATH: /home/${{ secrets.SSH_USER }}/astral
+#   BRANCH_NAME: ${{ github.ref_name }}
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
+# jobs:
+#   deploy:
+#     runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+#     steps:
+#       - name: Checkout code
+#         uses: actions/checkout@v3
 
-      - name: Set Hasura secret
-        id: set_secret
-        run: echo "hasura_secret=${{ secrets.HASURA_GRAPHQL_ADMIN_SECRET }}" >> $GITHUB_ENV
+#       - name: Set Hasura secret
+#         id: set_secret
+#         run: echo "hasura_secret=${{ secrets.HASURA_GRAPHQL_ADMIN_SECRET }}" >> $GITHUB_ENV
 
-      - name: Install SSH key
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SERVER_SSH_PRIVATE_KEY }}
+#       - name: Install SSH key
+#         uses: webfactory/ssh-agent@v0.9.0
+#         with:
+#           ssh-private-key: ${{ secrets.SERVER_SSH_PRIVATE_KEY }}
 
-      - name: Add SSH host key fingerprint
-        run: |
-          ssh-keyscan -H ${{ secrets.SUBQL_HOST }} >> ~/.ssh/known_hosts
+#       - name: Add SSH host key fingerprint
+#         run: |
+#           ssh-keyscan -H ${{ secrets.SUBQL_HOST }} >> ~/.ssh/known_hosts
 
-      - name: Deploy with Docker Compose
-        env:
-          SSH_USER: ${{ secrets.SSH_USER }}
-          HASURA_GRAPHQL_ADMIN_SECRET: ${{ secrets.HASURA_GRAPHQL_ADMIN_SECRET }}
-          HASURA_GRAPHQL_JWT_SECRET: ${{ secrets.HASURA_GRAPHQL_JWT_SECRET }}
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan -H ${{ secrets.SUBQL_HOST }} >> ~/.ssh/known_hosts
-          ssh ${SSH_USER}@${{ secrets.SUBQL_HOST }} "
+#       - name: Deploy with Docker Compose
+#         env:
+#           SSH_USER: ${{ secrets.SSH_USER }}
+#           HASURA_GRAPHQL_ADMIN_SECRET: ${{ secrets.HASURA_GRAPHQL_ADMIN_SECRET }}
+#           HASURA_GRAPHQL_JWT_SECRET: ${{ secrets.HASURA_GRAPHQL_JWT_SECRET }}
+#         run: |
+#           mkdir -p ~/.ssh
+#           ssh-keyscan -H ${{ secrets.SUBQL_HOST }} >> ~/.ssh/known_hosts
+#           ssh ${SSH_USER}@${{ secrets.SUBQL_HOST }} "
 
-            if [ ! -d ${DEPLOY_PATH} ]; then
-              git clone https://github.com/autonomys/astral.git ${DEPLOY_PATH}
-            else
-              cd ${DEPLOY_PATH}
-              git pull
-            fi
-            git checkout ${BRANCH_NAME}
+#             if [ ! -d ${DEPLOY_PATH} ]; then
+#               git clone https://github.com/autonomys/astral.git ${DEPLOY_PATH}
+#             else
+#               cd ${DEPLOY_PATH}
+#               git pull
+#             fi
+#             git checkout ${BRANCH_NAME}
 
-            # Securely update the .env file
-            if [ ! -f .env ]; then
-              echo 'HASURA_GRAPHQL_ADMIN_SECRET=${{ secrets.HASURA_GRAPHQL_ADMIN_SECRET }}' > .env
-              echo 'HASURA_GRAPHQL_JWT_SECRET=${{ secrets.HASURA_GRAPHQL_JWT_SECRET }}' >> .env
-            else
-              sed -i '/^HASURA_GRAPHQL_ADMIN_SECRET=/d' .env
-              echo 'HASURA_GRAPHQL_ADMIN_SECRET=${{ secrets.HASURA_GRAPHQL_ADMIN_SECRET }}' >> .env
-              sed -i '/^HASURA_GRAPHQL_JWT_SECRET=/d' .env
-              echo 'HASURA_GRAPHQL_JWT_SECRET=${{ secrets.HASURA_GRAPHQL_JWT_SECRET }}' >> .env
-            fi
+#             # Securely update the .env file
+#             if [ ! -f .env ]; then
+#               echo 'HASURA_GRAPHQL_ADMIN_SECRET=${{ secrets.HASURA_GRAPHQL_ADMIN_SECRET }}' > .env
+#               echo 'HASURA_GRAPHQL_JWT_SECRET=${{ secrets.HASURA_GRAPHQL_JWT_SECRET }}' >> .env
+#             else
+#               sed -i '/^HASURA_GRAPHQL_ADMIN_SECRET=/d' .env
+#               echo 'HASURA_GRAPHQL_ADMIN_SECRET=${{ secrets.HASURA_GRAPHQL_ADMIN_SECRET }}' >> .env
+#               sed -i '/^HASURA_GRAPHQL_JWT_SECRET=/d' .env
+#               echo 'HASURA_GRAPHQL_JWT_SECRET=${{ secrets.HASURA_GRAPHQL_JWT_SECRET }}' >> .env
+#             fi
 
-            export $(grep -v '^#' /home/${{ secrets.SSH_USER }}/astral/.env | xargs)
-            cd /home/${{ secrets.SSH_USER }}/astral/indexers
-            yarn build-dictionary
-            npx lerna run codegen
-            npx lerna run build
-            sudo docker compose -p prod-astral-indexers -f /home/${{ secrets.SSH_USER }}/astral/docker-compose.yml -f /home/${{ secrets.SSH_USER }}/astral/docker-compose.prod.yml --profile dictionary --profile task --profile taurus up -d --remove-orphans
-            echo 'Installation Complete'
-          "
+#             export $(grep -v '^#' /home/${{ secrets.SSH_USER }}/astral/.env | xargs)
+#             cd /home/${{ secrets.SSH_USER }}/astral/indexers
+#             yarn build-dictionary
+#             npx lerna run codegen
+#             npx lerna run build
+#             sudo docker compose -p prod-astral-indexers -f /home/${{ secrets.SSH_USER }}/astral/docker-compose.yml -f /home/${{ secrets.SSH_USER }}/astral/docker-compose.prod.yml --profile dictionary --profile task --profile taurus up -d --remove-orphans
+#             echo 'Installation Complete'
+#           "
 
-      - name: Notify on failure
-        if: failure()
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job
-          author_name: Deployment failed
-          mention: here
-          if_mention: failure,cancelled
-          job_name: Deploy Subql Green (staging)
-          channel: alerts
-          icon_emoji: ":github:"
+#       - name: Notify on failure
+#         if: failure()
+#         env:
+#           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+#         uses: 8398a7/action-slack@v3
+#         with:
+#           status: ${{ job.status }}
+#           fields: repo,message,commit,author,action,eventName,ref,workflow,job
+#           author_name: Deployment failed
+#           mention: here
+#           if_mention: failure,cancelled
+#           job_name: Deploy Subql Green (staging)
+#           channel: alerts
+#           icon_emoji: ":github:"


### PR DESCRIPTION
## Disable indexer workflow

This workflow injects wrongly formatted env on the server making hasura crash

Furthermore, this is not currently how we are using the green/blue indexers.

Most of the time we apply changes and re-sync the set of servers that is not in use by production, then when it's up to head, we switch production FE over to these server and test new changes on the release server.

So we don't want automated workflow that push update to a specific server since we currently rottate these two environment.