### PR TITLE
Extend api endpoints

### DIFF
--- a/indexers/api/src/app.module.ts
+++ b/indexers/api/src/app.module.ts
@@ -6,14 +6,21 @@ import { AccountsController } from './controllers/accounts.controller';
 import { AppController } from './controllers/app.controller';
 import { BlocksController } from './controllers/blocks.controller';
 import { ExtrinsicsController } from './controllers/extrinsics.controller';
-import { ApiKeysDailyUsage, ApiKeysMonthlyUsage } from './entities';
-import { Accounts } from './entities/consensus/accounts.entity';
-import { Blocks } from './entities/consensus/blocks.entity';
-import { Extrinsics } from './entities/consensus/extrinsics.entity';
-import { ApiDailyUsage } from './entities/users/api-daily-usage.entity';
-import { ApiKey } from './entities/users/api-key.entity';
-import { ApiMonthlyUsage } from './entities/users/api-monthly-usage.entity';
-import { Profile } from './entities/users/profile.entity';
+import {
+  Accounts,
+  ApiDailyUsage,
+  ApiKey,
+  ApiKeysDailyUsage,
+  ApiKeysMonthlyUsage,
+  ApiMonthlyUsage,
+  Blocks,
+  ConsensusMetadata,
+  Extrinsics,
+  FilesMetadata,
+  LeaderboardMetadata,
+  Profile,
+  StakingMetadata,
+} from './entities';
 import { ApiUsageService } from './services/api-usage.service';
 
 @Module({
@@ -35,6 +42,10 @@ import { ApiUsageService } from './services/api-usage.service';
         ApiKeysDailyUsage,
         ApiKeysMonthlyUsage,
         Accounts,
+        ConsensusMetadata,
+        LeaderboardMetadata,
+        FilesMetadata,
+        StakingMetadata,
       ],
       synchronize: false,
     }),
@@ -48,6 +59,10 @@ import { ApiUsageService } from './services/api-usage.service';
       ApiKeysDailyUsage,
       ApiKeysMonthlyUsage,
       Accounts,
+      ConsensusMetadata,
+      LeaderboardMetadata,
+      FilesMetadata,
+      StakingMetadata,
     ]),
     PassportModule.register({ defaultStrategy: 'api-key' }),
   ],

--- a/indexers/api/src/controllers/accounts.controller.ts
+++ b/indexers/api/src/controllers/accounts.controller.ts
@@ -12,6 +12,29 @@ export class AccountsController {
     private accountRepository: Repository<Accounts>,
   ) {}
 
+  @Get('count')
+  @ApiOperation({
+    operationId: 'getAccountsCount',
+    summary: 'Get total number of accounts',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Total number of accounts retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        count: {
+          type: 'number',
+          description: 'Total number of accounts',
+        },
+      },
+    },
+  })
+  async getAccountsCount() {
+    const count = await this.accountRepository.count();
+    return { count };
+  }
+
   @Get(':accountId')
   @ApiOperation({
     operationId: 'getAccountById',

--- a/indexers/api/src/controllers/app.controller.ts
+++ b/indexers/api/src/controllers/app.controller.ts
@@ -2,13 +2,27 @@ import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Blocks } from '../entities/consensus/blocks.entity';
+import {
+  Blocks,
+  ConsensusMetadata,
+  FilesMetadata,
+  LeaderboardMetadata,
+  StakingMetadata,
+} from '../entities';
 
 @Controller()
 export class AppController {
   constructor(
     @InjectRepository(Blocks)
     private blocksRepository: Repository<Blocks>,
+    @InjectRepository(ConsensusMetadata)
+    private consensusMetadataRepository: Repository<ConsensusMetadata>,
+    @InjectRepository(LeaderboardMetadata)
+    private leaderboardMetadataRepository: Repository<LeaderboardMetadata>,
+    @InjectRepository(FilesMetadata)
+    private filesMetadataRepository: Repository<FilesMetadata>,
+    @InjectRepository(StakingMetadata)
+    private stakingMetadataRepository: Repository<StakingMetadata>,
   ) {}
 
   @Get()
@@ -54,5 +68,82 @@ export class AppController {
       .getOne();
 
     return latestBlock.blockchain_size;
+  }
+
+  @Get('health')
+  @ApiOperation({
+    operationId: 'getHealth',
+    summary: 'Get all indexers health status',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the health status for all indexers',
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          indexer: {
+            type: 'string',
+            description: 'Name of the indexer',
+          },
+          lastProcessedHeight: {
+            type: 'number',
+            description: 'Last processed block height',
+          },
+          targetHeight: {
+            type: 'number',
+            description: 'Target block height to process',
+          },
+          isSynced: {
+            type: 'boolean',
+            description: 'Whether the indexer is synced with the chain',
+          },
+        },
+      },
+    },
+  })
+  async getHealth() {
+    const indexers = [
+      {
+        name: 'consensus',
+        repository: this.consensusMetadataRepository,
+      },
+      {
+        name: 'leaderboard',
+        repository: this.leaderboardMetadataRepository,
+      },
+      {
+        name: 'files',
+        repository: this.filesMetadataRepository,
+      },
+      {
+        name: 'staking',
+        repository: this.stakingMetadataRepository,
+      },
+    ];
+
+    const results = await Promise.all(
+      indexers.map(async ({ name, repository }) => {
+        const [lastProcessedHeight, targetHeight] = await Promise.all([
+          repository.findOne({
+            where: { key: 'lastProcessedHeight' },
+          }),
+          repository.findOne({ where: { key: 'targetHeight' } }),
+        ]);
+
+        const processedHeight = lastProcessedHeight?.value || 0;
+        const currentTarget = targetHeight?.value || 0;
+
+        return {
+          indexer: name,
+          lastProcessedHeight: processedHeight,
+          targetHeight: currentTarget,
+          isSynced: processedHeight >= currentTarget,
+        };
+      }),
+    );
+
+    return results;
   }
 }

--- a/indexers/api/src/controllers/extrinsics.controller.ts
+++ b/indexers/api/src/controllers/extrinsics.controller.ts
@@ -3,10 +3,12 @@ import {
   Get,
   NotFoundException,
   Param,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiSecurity,
   ApiTags,
@@ -25,6 +27,63 @@ export class ExtrinsicsController {
     @InjectRepository(Extrinsics)
     private extrinsicsRepository: Repository<Extrinsics>,
   ) {}
+
+  @Get('account/:accountId')
+  @ApiOperation({
+    operationId: 'getExtrinsicsByAccount',
+    summary: 'Get extrinsics by account ID (signer)',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number (starts from 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'order',
+    required: false,
+    type: String,
+    description: 'Sort order by timestamp',
+    enum: ['asc', 'desc'],
+    default: 'desc',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the extrinsics for the account',
+    type: [Extrinsics],
+  })
+  async findByAccount(
+    @Param('accountId') accountId: string,
+    @Query('page') page: number = 1,
+    @Query('order') order: 'asc' | 'desc' = 'desc',
+  ) {
+    const take = 100;
+    const skip = (page - 1) * take;
+
+    const [extrinsics, total] = await this.extrinsicsRepository.findAndCount({
+      where: { signer: accountId },
+      order: { timestamp: order },
+      take,
+      skip,
+    });
+
+    if (extrinsics.length === 0 && page === 1) {
+      throw new NotFoundException(
+        `No extrinsics found for account ${accountId}`,
+      );
+    }
+
+    return {
+      items: extrinsics,
+      metadata: {
+        total,
+        page,
+        pageSize: take,
+        pageCount: Math.ceil(total / take),
+      },
+    };
+  }
 
   @Get(':hash')
   @ApiOperation({

--- a/indexers/api/src/entities/consensus/metadata.entity.ts
+++ b/indexers/api/src/entities/consensus/metadata.entity.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('_metadata', { schema: 'consensus' })
+export class ConsensusMetadata {
+  @ApiProperty()
+  @PrimaryColumn('varchar', { unique: true })
+  key: string;
+
+  @ApiProperty()
+  @Column('jsonb', { nullable: true })
+  value: any;
+
+  @ApiProperty()
+  @Column('timestamp with time zone')
+  createdAt: Date;
+
+  @ApiProperty()
+  @Column('timestamp with time zone')
+  updatedAt: Date;
+}

--- a/indexers/api/src/entities/files/metadata.entity.ts
+++ b/indexers/api/src/entities/files/metadata.entity.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('_metadata', { schema: 'files' })
+export class FilesMetadata {
+  @ApiProperty()
+  @PrimaryColumn('varchar', { unique: true })
+  key: string;
+
+  @ApiProperty()
+  @Column('jsonb', { nullable: true })
+  value: any;
+
+  @ApiProperty()
+  @Column('timestamp with time zone')
+  createdAt: Date;
+
+  @ApiProperty()
+  @Column('timestamp with time zone')
+  updatedAt: Date;
+}

--- a/indexers/api/src/entities/index.ts
+++ b/indexers/api/src/entities/index.ts
@@ -17,6 +17,16 @@ export * from './consensus/extrinsic_modules.entity';
 export * from './consensus/extrinsics.entity';
 export * from './consensus/log_kinds.entity';
 export * from './consensus/logs.entity';
+export * from './consensus/metadata.entity';
 export * from './consensus/rewards.entity';
 export * from './consensus/sections.entity';
 export * from './consensus/transfers.entity';
+
+// Leaderboard Entities
+export * from './leaderboard/metadata.entity';
+
+// Files Entities
+export * from './files/metadata.entity';
+
+// Staking Entities
+export * from './staking/metadata.entity';

--- a/indexers/api/src/entities/leaderboard/metadata.entity.ts
+++ b/indexers/api/src/entities/leaderboard/metadata.entity.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('_metadata', { schema: 'leaderboard' })
+export class LeaderboardMetadata {
+  @ApiProperty()
+  @PrimaryColumn('varchar', { unique: true })
+  key: string;
+
+  @ApiProperty()
+  @Column('jsonb', { nullable: true })
+  value: any;
+
+  @ApiProperty()
+  @Column('timestamp with time zone')
+  createdAt: Date;
+
+  @ApiProperty()
+  @Column('timestamp with time zone')
+  updatedAt: Date;
+}

--- a/indexers/api/src/entities/staking/metadata.entity.ts
+++ b/indexers/api/src/entities/staking/metadata.entity.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('_metadata', { schema: 'staking' })
+export class StakingMetadata {
+  @ApiProperty()
+  @PrimaryColumn('varchar', { unique: true })
+  key: string;
+
+  @ApiProperty()
+  @Column('jsonb', { nullable: true })
+  value: any;
+
+  @ApiProperty()
+  @Column('timestamp with time zone')
+  createdAt: Date;
+
+  @ApiProperty()
+  @Column('timestamp with time zone')
+  updatedAt: Date;
+}

--- a/indexers/api/src/services/api-usage.service.ts
+++ b/indexers/api/src/services/api-usage.service.ts
@@ -62,10 +62,8 @@ export class ApiUsageService {
           })
           .getOne();
 
-        if (
-          profile.api_daily_requests_limit <=
-          (apiDailyUsage?.total_requests || 0) + 1
-        )
+        const newApiDailyUsage = Number(apiDailyUsage.total_requests) + 1;
+        if (profile.api_daily_requests_limit <= newApiDailyUsage)
           throw new ApiUsageLimitException('Daily requests limit exceeded');
 
         const apiMonthlyUsage = await transactionalEntityManager
@@ -76,10 +74,8 @@ export class ApiUsageService {
           })
           .getOne();
 
-        if (
-          profile.api_monthly_requests_limit <=
-          (apiMonthlyUsage?.total_requests || 0) + 1
-        )
+        const newApiMonthlyUsage = Number(apiMonthlyUsage.total_requests) + 1;
+        if (profile.api_monthly_requests_limit <= newApiMonthlyUsage)
           throw new ApiUsageLimitException('Monthly requests limit exceeded');
 
         await transactionalEntityManager


### PR DESCRIPTION
## Extend api endpoints

- Add a health/ endpoint returning the indexing status of the 4 indexers
- Add accounts/count returning the amount of accounts
- Add extrinsics/account/:id returning extrinsics for a account (paginated by 100)