### PR TITLE
Fix latest rewards cascading

### DIFF
--- a/explorer/src/components/Consensus/Account/AccountLatestRewards.tsx
+++ b/explorer/src/components/Consensus/Account/AccountLatestRewards.tsx
@@ -25,28 +25,28 @@ export const AccountLatestRewards: FC<AccountLatestRewardsProps> = ({ rewards })
     <div className='flex w-full flex-col rounded-[20px] border border-gray-200 px-4 dark:border-none'>
       <div className='flex w-full flex-col gap-6 pl-4'>
         <div className='flex w-full justify-between'>
-          <div className='text-blueShade flex-1 grow text-[13px] font-normal dark:text-white/75'>
+          <div className='flex-1 grow text-[13px] font-normal text-blueShade dark:text-white/75'>
             Block Number
           </div>
-          <div className='text-blueShade flex-1 grow text-center text-[13px] font-normal dark:text-white/75'>
+          <div className='flex-1 grow text-center text-[13px] font-normal text-blueShade dark:text-white/75'>
             Type
           </div>
-          <div className='text-blueShade flex-1 grow text-end text-[13px] font-normal dark:text-white/75'>
+          <div className='flex-1 grow text-end text-[13px] font-normal text-blueShade dark:text-white/75'>
             Amount
           </div>
         </div>
         <div className='w-full'>
-          <ol className='dark:border-buttonDarkFrom border-buttonLightFrom relative w-full border-l'>
+          <ol className='relative w-full border-l border-buttonLightFrom dark:border-buttonDarkFrom'>
             {rewards.map(({ id, rewardType, blockHeight, amount }, index) => {
               const confirmations = lastBlockNumber ? Math.max(0, lastBlockNumber - blockHeight) : 0
               return (
                 <li
                   key={`${id}-account-rewards-block`}
-                  className={`flex w-full justify-between ${
+                  className={`flex w-full items-center justify-between ${
                     index !== rewards.length - 1 && 'mb-[26px]'
                   }`}
                 >
-                  <div className='w-full flex-1 grow'>
+                  <div className='flex w-full flex-1 grow items-center'>
                     <div
                       className={`absolute -left-1.5 size-3 rounded-full ${
                         index === 0
@@ -54,7 +54,7 @@ export const AccountLatestRewards: FC<AccountLatestRewardsProps> = ({ rewards })
                           : 'bg-buttonDarkFrom dark:bg-buttonDarkTo'
                       }`}
                     ></div>
-                    <div className='-mt-1 ml-4 flex-1 grow text-[13px] font-normal text-grayDark dark:text-white '>
+                    <div className='-mt-1 ml-4 flex flex-1 grow items-center text-[13px] font-normal text-grayDark dark:text-white'>
                       <Link
                         key={`${id}-account-index`}
                         className='hover:text-primaryAccent'
@@ -92,7 +92,7 @@ export const AccountLatestRewards: FC<AccountLatestRewardsProps> = ({ rewards })
           onClick={() =>
             push(INTERNAL_ROUTES.accounts.rewards.page(network, section, accountId || ''))
           }
-          className='bg-blueLight mt-4 w-full rounded-[20px] py-4 dark:bg-whiteTransparent dark:text-white'
+          className='mt-4 w-full rounded-[20px] bg-blueLight py-4 dark:bg-whiteTransparent dark:text-white'
         >
           See All Rewards
         </button>


### PR DESCRIPTION
## Fix latest rewards cascading

In the account details page, the latest rewards were cascading resulting in a overflowing of the box