### PR TITLE
Improve consensus indexer indexes

### DIFF
--- a/indexers/db/docker-entrypoint-initdb.d/init-db.sql
+++ b/indexers/db/docker-entrypoint-initdb.d/init-db.sql
@@ -1344,10 +1344,12 @@ ALTER TABLE ONLY files.metadata
 CREATE INDEX "0xccedb032815757ed" ON consensus.blocks USING btree (id);
 CREATE INDEX "consensus_blocks_sort_id" ON consensus.blocks USING btree (sort_id DESC);
 CREATE INDEX "consensus_blocks_hash" ON consensus.blocks USING btree (hash);
+CREATE INDEX "consensus_blocks_id_hash" ON consensus.blocks (id, hash);
 CREATE INDEX "0xd8db4c8313621519" ON consensus.extrinsics USING btree (id);
 CREATE INDEX "consensus_extrinsics_sort_id" ON consensus.extrinsics USING btree (sort_id DESC);
 CREATE INDEX "consensus_extrinsics_hash" ON consensus.extrinsics USING btree (hash);
 CREATE INDEX "consensus_extrinsics_block_height" ON consensus.extrinsics USING btree (block_height);
+CREATE INDEX "consensus_extrinsics_signer" ON consensus.extrinsics USING btree (signer);
 CREATE INDEX "0xe5bf5858bd35a276" ON consensus.events USING btree (id);
 CREATE INDEX "consensus_events_sort_id" ON consensus.events USING btree (sort_id DESC);
 CREATE INDEX "consensus_events_extrinsic_id" ON consensus.events USING btree (extrinsic_id);
@@ -1367,6 +1369,8 @@ CREATE INDEX "0x3d8ee08d232943ea" ON consensus.sections USING btree (id);
 CREATE INDEX "0x1e967733a0d5db15" ON consensus.rewards USING btree (id);
 CREATE INDEX "consensus_rewards_account_id" ON consensus.rewards USING btree (account_id);
 CREATE INDEX "0x09a98aa53fa2c2e3" ON consensus.logs USING btree (id);
+CREATE INDEX "consensus_logs_sort_id" ON consensus.logs USING btree (sort_id DESC);
+CREATE INDEX "consensus_logs_block_height" ON consensus.logs USING btree (block_height);
 
 CREATE INDEX "0x288575ef7a7aaf75" ON dictionary.extrinsics USING btree (module);
 CREATE INDEX "0x46e7a495bb4c21d1" ON dictionary.events USING btree (event);

--- a/indexers/yarn.lock
+++ b/indexers/yarn.lock
@@ -2870,6 +2870,11 @@
   resolved "https://registry.yarnpkg.com/@types/methods/-/methods-1.1.4.tgz#d3b7ac30ac47c91054ea951ce9eed07b1051e547"
   integrity sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==
 
+"@types/mime-types@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.4.tgz#93a1933e24fed4fb9e4adc5963a63efcbb3317a2"
+  integrity sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==
+
 "@types/mime@^1":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"
@@ -7642,7 +7647,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
## Improve consensus indexer indexes

To improve block detail page, I'm adding
`CREATE INDEX "consensus_blocks_id_hash" ON consensus.blocks (id, hash);` since the query do a where id or hash

To improve the account details page, I'm adding
`CREATE INDEX "consensus_extrinsics_signer" ON consensus.extrinsics USING btree (signer);` to serve the extrinsics of an account faster

To improve the logs list page, I'm adding
`CREATE INDEX "consensus_logs_sort_id" ON consensus.logs USING btree (sort_id DESC);`

To improve the block details page, I'm adding
`CREATE INDEX "consensus_logs_block_height" ON consensus.logs USING btree (block_height);` as the block details page query the related logs of a block

***The indexes have been manually added to both blue instances already!***