### PR TITLE
fix(ui): 🐛 out of sync banner overflow user profile sidebar

### DIFF
--- a/explorer/src/components/common/OutOfSyncBanner.tsx
+++ b/explorer/src/components/common/OutOfSyncBanner.tsx
@@ -16,7 +16,7 @@ const OutOfSyncBanner: FC = () => {
   const { network } = useIndexers()
   return (
     <div className='container mx-auto mb-4 flex grow justify-center px-5 md:px-[25px] 2xl:px-0'>
-      <div className='sticky top-0 z-50 w-full'>
+      <div className='sticky top-0 z-10 w-full'>
         <div className='w-full rounded-[20px] bg-[#DDEFF1] p-5 shadow dark:border-none dark:bg-boxDark'>
           <div className='flex flex-col gap-4'>
             <div className='text-[20px] font-bold text-[#282929] dark:text-white'>


### PR DESCRIPTION
## Before
![Screenshot 2025-01-31 000106](https://github.com/user-attachments/assets/82dbcd7a-3d06-43f5-b3a3-f0da9b0643b5)

## After
![Screenshot 2025-01-31 000221](https://github.com/user-attachments/assets/ec05cb3e-b6e2-4996-941e-e00598687174)
