### PR TITLE
Improve accounts list query speed

### DIFF
--- a/explorer/gql/graphql.tsx
+++ b/explorer/gql/graphql.tsx
@@ -20600,7 +20600,7 @@ export type AccountsQueryVariables = Exact<{
 }>;
 
 
-export type AccountsQuery = { __typename?: 'query_root', consensus_accounts_aggregate: { __typename?: 'consensus_accounts_aggregate', aggregate?: { __typename?: 'consensus_accounts_aggregate_fields', count: number } | null }, consensus_accounts: Array<{ __typename?: 'consensus_accounts', id: string, nonce: any, free: any, reserved: any, total?: any | null, createdAt: any, updatedAt: any, extrinsicsCount: { __typename?: 'consensus_extrinsics_aggregate', aggregate?: { __typename?: 'consensus_extrinsics_aggregate_fields', count: number } | null } }> };
+export type AccountsQuery = { __typename?: 'query_root', consensus_accounts_aggregate: { __typename?: 'consensus_accounts_aggregate', aggregate?: { __typename?: 'consensus_accounts_aggregate_fields', count: number } | null }, consensus_accounts: Array<{ __typename?: 'consensus_accounts', id: string, nonce: any, free: any, reserved: any, total?: any | null, createdAt: any, updatedAt: any }> };
 
 export type AccountByIdQueryVariables = Exact<{
   accountId: Scalars['String']['input'];
@@ -20656,13 +20656,6 @@ export type BalanceHistoryByAccountIdQueryVariables = Exact<{
 
 
 export type BalanceHistoryByAccountIdQuery = { __typename?: 'query_root', consensus_account_histories_aggregate: { __typename?: 'consensus_account_histories_aggregate', aggregate?: { __typename?: 'consensus_account_histories_aggregate_fields', count: number } | null }, consensus_account_histories: Array<{ __typename?: 'consensus_account_histories', reserved: any, total?: any | null, nonce: any, free: any, created_at: any, _block_range: any, id: any }> };
-
-export type AllRewardForAccountByIdQueryVariables = Exact<{
-  accountId: Scalars['String']['input'];
-}>;
-
-
-export type AllRewardForAccountByIdQuery = { __typename?: 'query_root', consensus_rewards: Array<{ __typename?: 'consensus_rewards', id: string, block_height: any, reward_type: string, amount: any, timestamp: any }> };
 
 export type BlocksQueryVariables = Exact<{
   limit: Scalars['Int']['input'];
@@ -21205,11 +21198,6 @@ export const AccountsDocument = gql`
     total
     createdAt: created_at
     updatedAt: updated_at
-    extrinsicsCount: extrinsics_aggregate {
-      aggregate {
-        count
-      }
-    }
   }
 }
     `;
@@ -21609,53 +21597,6 @@ export type BalanceHistoryByAccountIdQueryHookResult = ReturnType<typeof useBala
 export type BalanceHistoryByAccountIdLazyQueryHookResult = ReturnType<typeof useBalanceHistoryByAccountIdLazyQuery>;
 export type BalanceHistoryByAccountIdSuspenseQueryHookResult = ReturnType<typeof useBalanceHistoryByAccountIdSuspenseQuery>;
 export type BalanceHistoryByAccountIdQueryResult = Apollo.QueryResult<BalanceHistoryByAccountIdQuery, BalanceHistoryByAccountIdQueryVariables>;
-export const AllRewardForAccountByIdDocument = gql`
-    query AllRewardForAccountById($accountId: String!) {
-  consensus_rewards(
-    where: {account_id: {_eq: $accountId}, amount: {_gt: 0}}
-    limit: 1
-  ) {
-    id
-    block_height
-    reward_type
-    amount
-    timestamp
-  }
-}
-    `;
-
-/**
- * __useAllRewardForAccountByIdQuery__
- *
- * To run a query within a React component, call `useAllRewardForAccountByIdQuery` and pass it any options that fit your needs.
- * When your component renders, `useAllRewardForAccountByIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useAllRewardForAccountByIdQuery({
- *   variables: {
- *      accountId: // value for 'accountId'
- *   },
- * });
- */
-export function useAllRewardForAccountByIdQuery(baseOptions: Apollo.QueryHookOptions<AllRewardForAccountByIdQuery, AllRewardForAccountByIdQueryVariables> & ({ variables: AllRewardForAccountByIdQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<AllRewardForAccountByIdQuery, AllRewardForAccountByIdQueryVariables>(AllRewardForAccountByIdDocument, options);
-      }
-export function useAllRewardForAccountByIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AllRewardForAccountByIdQuery, AllRewardForAccountByIdQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<AllRewardForAccountByIdQuery, AllRewardForAccountByIdQueryVariables>(AllRewardForAccountByIdDocument, options);
-        }
-export function useAllRewardForAccountByIdSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<AllRewardForAccountByIdQuery, AllRewardForAccountByIdQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<AllRewardForAccountByIdQuery, AllRewardForAccountByIdQueryVariables>(AllRewardForAccountByIdDocument, options);
-        }
-export type AllRewardForAccountByIdQueryHookResult = ReturnType<typeof useAllRewardForAccountByIdQuery>;
-export type AllRewardForAccountByIdLazyQueryHookResult = ReturnType<typeof useAllRewardForAccountByIdLazyQuery>;
-export type AllRewardForAccountByIdSuspenseQueryHookResult = ReturnType<typeof useAllRewardForAccountByIdSuspenseQuery>;
-export type AllRewardForAccountByIdQueryResult = Apollo.QueryResult<AllRewardForAccountByIdQuery, AllRewardForAccountByIdQueryVariables>;
 export const BlocksDocument = gql`
     query Blocks($limit: Int!, $offset: Int, $orderBy: [consensus_blocks_order_by!]!, $where: consensus_blocks_bool_exp) {
   consensus_blocks_aggregate(where: $where) {

--- a/explorer/gql/graphql.tsx
+++ b/explorer/gql/graphql.tsx
@@ -20607,7 +20607,7 @@ export type AccountByIdQueryVariables = Exact<{
 }>;
 
 
-export type AccountByIdQuery = { __typename?: 'query_root', consensus_account_histories: Array<{ __typename?: 'consensus_account_histories', id: string, free: any, reserved: any, total?: any | null, nonce: any }>, consensus_rewards: Array<{ __typename?: 'consensus_rewards', id: string, amount: any, timestamp: any, blockHeight: any, rewardType: string }> };
+export type AccountByIdQuery = { __typename?: 'query_root', consensus_accounts_by_pk?: { __typename?: 'consensus_accounts', id: string, free: any, reserved: any, total?: any | null, nonce: any } | null, consensus_rewards: Array<{ __typename?: 'consensus_rewards', id: string, amount: any, timestamp: any, blockHeight: any, rewardType: string }> };
 
 export type LatestRewardsWeekQueryVariables = Exact<{
   accountId: Scalars['String']['input'];
@@ -21239,11 +21239,7 @@ export type AccountsSuspenseQueryHookResult = ReturnType<typeof useAccountsSuspe
 export type AccountsQueryResult = Apollo.QueryResult<AccountsQuery, AccountsQueryVariables>;
 export const AccountByIdDocument = gql`
     query AccountById($accountId: String!) {
-  consensus_account_histories(
-    where: {id: {_eq: $accountId}}
-    limit: 1
-    order_by: {_block_range: desc}
-  ) {
+  consensus_accounts_by_pk(id: $accountId) {
     id
     free
     reserved

--- a/explorer/src/app/[chain]/consensus/accounts/[accountId]/image/route.tsx
+++ b/explorer/src/app/[chain]/consensus/accounts/[accountId]/image/route.tsx
@@ -24,7 +24,7 @@ export async function GET(
   if (!accountId || !chainMatch) notFound()
 
   const {
-    data: { consensus_account_histories: accountById },
+    data: { consensus_accounts_by_pk: accountById },
   }: {
     data: AccountByIdQuery
   } = await fetch(chainMatch.indexer, {
@@ -46,7 +46,7 @@ export async function GET(
         <Screen
           chainMatch={chainMatch}
           accountId={accountId}
-          accountById={accountById[0]}
+          accountById={accountById}
           tokenSymbol={tokenSymbol}
         />
       ),
@@ -69,7 +69,7 @@ function Screen({
 }: {
   chainMatch: (typeof indexers)[number]
   accountId: string
-  accountById: AccountByIdQuery['consensus_account_histories'][number]
+  accountById: AccountByIdQuery['consensus_accounts_by_pk']
   tokenSymbol: string
 }) {
   const account = {

--- a/explorer/src/components/Consensus/Account/Account.tsx
+++ b/explorer/src/components/Consensus/Account/Account.tsx
@@ -47,7 +47,7 @@ export const Account: FC = () => {
     if (hasValue(consensusEntry)) return consensusEntry.value
   }, [consensusEntry])
 
-  const account = useMemo(() => data && data.consensus_account_histories[0], [data])
+  const account = useMemo(() => data && data.consensus_accounts_by_pk, [data])
   const rewards = useMemo(() => (data ? data.consensus_rewards : []), [data])
 
   useEffect(() => {

--- a/explorer/src/components/Consensus/Account/AccountBalancePieChart.tsx
+++ b/explorer/src/components/Consensus/Account/AccountBalancePieChart.tsx
@@ -5,7 +5,7 @@ import { FC } from 'react'
 import { bigNumberToNumber } from 'utils/number'
 
 type Props = {
-  account: AccountByIdQuery['consensus_account_histories'][number] | undefined
+  account: AccountByIdQuery['consensus_accounts_by_pk'] | undefined
 }
 
 export const AccountBalancePieChart: FC<Props> = ({ account }) => {

--- a/explorer/src/components/Consensus/Account/AccountBalanceStats.tsx
+++ b/explorer/src/components/Consensus/Account/AccountBalanceStats.tsx
@@ -6,7 +6,7 @@ import { bigNumberToNumber, numberWithCommas } from 'utils/number'
 import { AccountBalancePieChart } from './AccountBalancePieChart'
 
 type Props = {
-  account: AccountByIdQuery['consensus_account_histories'][number] | undefined
+  account: AccountByIdQuery['consensus_accounts_by_pk'] | undefined
   isDesktop?: boolean
 }
 

--- a/explorer/src/components/Consensus/Account/AccountDetailsCard.tsx
+++ b/explorer/src/components/Consensus/Account/AccountDetailsCard.tsx
@@ -8,7 +8,7 @@ import { accountIdToHex } from 'utils//formatAddress'
 import { AccountIcon } from '../../common/AccountIcon'
 
 type Props = {
-  account: AccountByIdQuery['consensus_account_histories'][number] | undefined
+  account: AccountByIdQuery['consensus_accounts_by_pk'] | undefined
   accountAddress: string
   isDesktop?: boolean
 }
@@ -16,7 +16,7 @@ type Props = {
 export const AccountDetailsCard: FC<Props> = ({ account, accountAddress, isDesktop = false }) => {
   const publicKey = accountIdToHex(accountAddress)
   return (
-    <div className='dark:bg-boxDark mb-4 rounded-[20px] border border-slate-100 bg-white p-6 shadow dark:border-none md:p-4'>
+    <div className='mb-4 rounded-[20px] border border-slate-100 bg-white p-6 shadow dark:border-none dark:bg-boxDark md:p-4'>
       <div className='flex w-full items-center gap-3'>
         <Accordion
           title={

--- a/explorer/src/components/Consensus/Account/AccountGraphs.tsx
+++ b/explorer/src/components/Consensus/Account/AccountGraphs.tsx
@@ -5,7 +5,7 @@ import { AccountBalanceStats } from './AccountBalanceStats'
 import { AccountGraphTabs } from './AccountGraphTabs'
 
 type Props = {
-  account: AccountByIdQuery['consensus_account_histories'][number] | undefined
+  account: AccountByIdQuery['consensus_accounts_by_pk'] | undefined
   isDesktop?: boolean
 }
 

--- a/explorer/src/components/Consensus/Account/AccountList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountList.tsx
@@ -31,7 +31,7 @@ const TABLE = 'accounts'
 export const AccountList: FC = () => {
   const { ref, inView } = useInView()
   const { network, section, tokenDecimals } = useIndexers()
-  const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'total', desc: true }])
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,
     pageIndex: 0,
@@ -56,7 +56,7 @@ export const AccountList: FC = () => {
         ? sorting[0].id.endsWith('aggregate')
           ? { [sorting[0].id]: sorting[0].desc ? { count: OrderBy.Desc } : { count: OrderBy.Asc } }
           : { [sorting[0].id]: sorting[0].desc ? OrderBy.Desc : OrderBy.Asc }
-        : { id: OrderBy.Asc },
+        : { total: OrderBy.Desc },
     [sorting],
   )
 

--- a/explorer/src/components/Consensus/Account/AccountList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountList.tsx
@@ -180,8 +180,6 @@ export const AccountList: FC = () => {
             <AccountIconWithLink address={row.original.id} network={network} section={section} />
           ),
           nonce: ({ row }: Cell<Row>) => row.original.nonce.toString(),
-          extrinsicsCount: ({ row }: Cell<Row>) =>
-            row.original.extrinsicsCount.aggregate?.count.toString() || '0',
           free: ({ row }: Cell<Row>) => numberWithCommas(bigNumberToNumber(row.original.free)),
           reserved: ({ row }: Cell<Row>) =>
             numberWithCommas(bigNumberToNumber(row.original.reserved)),

--- a/explorer/src/components/Consensus/Account/AccountRewardList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountRewardList.tsx
@@ -105,7 +105,7 @@ export const AccountRewardList: FC = () => {
   const account = useMemo(
     () =>
       rewards
-        ? (rewards[0].account as unknown as AccountByIdQuery['consensus_account_histories'][number])
+        ? (rewards[0].account as unknown as AccountByIdQuery['consensus_accounts_by_pk'])
         : undefined,
     [rewards],
   )

--- a/explorer/src/components/Consensus/Account/query.ts
+++ b/explorer/src/components/Consensus/Account/query.ts
@@ -20,11 +20,6 @@ export const QUERY_ACCOUNTS = gql`
       total
       createdAt: created_at
       updatedAt: updated_at
-      extrinsicsCount: extrinsics_aggregate {
-        aggregate {
-          count
-        }
-      }
     }
   }
 `
@@ -187,18 +182,6 @@ export const QUERY_ACCOUNT_BALANCE_HISTORY = gql`
       free
       created_at
       _block_range
-    }
-  }
-`
-
-export const QUERY_ALL_REWARDS_FOR_ACCOUNT_BY_ID = gql`
-  query AllRewardForAccountById($accountId: String!) {
-    consensus_rewards(where: { account_id: { _eq: $accountId }, amount: { _gt: 0 } }, limit: 1) {
-      id
-      block_height
-      reward_type
-      amount
-      timestamp
     }
   }
 `

--- a/explorer/src/components/Consensus/Account/query.ts
+++ b/explorer/src/components/Consensus/Account/query.ts
@@ -26,11 +26,7 @@ export const QUERY_ACCOUNTS = gql`
 
 export const QUERY_ACCOUNT_BY_ID = gql`
   query AccountById($accountId: String!) {
-    consensus_account_histories(
-      where: { id: { _eq: $accountId } }
-      limit: 1
-      order_by: { _block_range: desc }
-    ) {
+    consensus_accounts_by_pk(id: $accountId) {
       id
       free
       reserved

--- a/explorer/src/constants/indexers.ts
+++ b/explorer/src/constants/indexers.ts
@@ -7,7 +7,7 @@ export interface Indexer {
   telemetryNetworkName?: string
 }
 
-const LOCAL_INDEXER = 'https://subql.green.mainnet.subspace.network/v1/graphql'
+const LOCAL_INDEXER = 'http://localhost:8080/v1/graphql'
 
 export const indexers: Indexer[] = [
   {

--- a/explorer/src/constants/indexers.ts
+++ b/explorer/src/constants/indexers.ts
@@ -7,7 +7,7 @@ export interface Indexer {
   telemetryNetworkName?: string
 }
 
-const LOCAL_INDEXER = 'http://localhost:8080/v1/graphql'
+const LOCAL_INDEXER = 'https://subql.green.mainnet.subspace.network/v1/graphql'
 
 export const indexers: Indexer[] = [
   {

--- a/explorer/src/constants/tables.ts
+++ b/explorer/src/constants/tables.ts
@@ -353,8 +353,8 @@ export const INITIAL_TABLES: InitialTables = {
     },
     sorting: [
       {
-        id: 'id',
-        desc: false,
+        id: 'total',
+        desc: true,
       },
     ],
   },

--- a/explorer/src/constants/tables.ts
+++ b/explorer/src/constants/tables.ts
@@ -6,9 +6,8 @@ import { OperatorStatus } from './staking'
 export const AVAILABLE_COLUMNS: AvailableColumns = {
   accounts: [
     { name: 'id', label: 'Account', isSelected: true, searchable: true },
-    { name: 'nonce', label: 'Nonce', isSelected: false },
-    { name: 'extrinsicsCount', label: 'Extrinsics', isSelected: true },
-    { name: 'free', label: 'Free', isSelected: false },
+    { name: 'nonce', label: 'Nonce', isSelected: true },
+    { name: 'free', label: 'Free', isSelected: true },
     { name: 'reserved', label: 'Locked', isSelected: true },
     { name: 'total', label: 'Balance', isSelected: true },
     { name: 'createdAt', label: 'Created At', isSelected: false },

--- a/explorer/src/states/query.ts
+++ b/explorer/src/states/query.ts
@@ -42,7 +42,6 @@ interface ExplorerQueryState {
     log: QueryState<GqlT.LogByIdQuery>
 
     accountExtrinsic: QueryState<GqlT.ExtrinsicsByAccountIdQuery>
-    accountPreviousReward: QueryState<GqlT.AllRewardForAccountByIdQuery>
     accountRewardGraph: QueryState<GqlT.LatestRewardsWeekQuery>
     accountReward: QueryState<GqlT.RewardsListQuery>
     accountTransfers: QueryState<GqlT.TransfersByAccountIdQuery>
@@ -112,7 +111,6 @@ const initialState: ExplorerQueryState = {
     log: initialized,
 
     accountExtrinsic: initialized,
-    accountPreviousReward: initialized,
     accountRewardGraph: initialized,
     accountReward: initialized,
     accountTransfers: initialized,


### PR DESCRIPTION
## Improve accounts list query speed

- Remove the extrinsicsCount that was performing a aggregate count on each accounts from the query and logic
- Simplify the account details query to query from the accounts table instead of the much larger account_histories table (now that the accounts table update is fix)