### PR TITLE
Add an eventscount to the consensusextrinsics table and logic to indexer

### DIFF
--- a/indexers/consensus/schema.graphql
+++ b/indexers/consensus/schema.graphql
@@ -51,6 +51,7 @@ type Extrinsic @entity {
   nonce: BigInt!
   signer: String!
   signature: String!
+  eventsCount: Int!
   args: String!
   error: String!
   tip: BigInt!

--- a/indexers/consensus/src/mappings/db.ts
+++ b/indexers/consensus/src/mappings/db.ts
@@ -111,6 +111,7 @@ export function createExtrinsic(
     nonce,
     signer,
     signature,
+    eventsCount,
     args,
     error,
     tip,

--- a/indexers/consensus/src/mappings/db.ts
+++ b/indexers/consensus/src/mappings/db.ts
@@ -86,6 +86,7 @@ export function createExtrinsic(
   nonce: bigint,
   signer: string,
   signature: string,
+  eventsCount: number,
   args: string,
   error: string,
   tip: bigint,

--- a/indexers/consensus/src/mappings/mappingHandlers.ts
+++ b/indexers/consensus/src/mappings/mappingHandlers.ts
@@ -160,6 +160,7 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
         BigInt(extrinsic.nonce.toString()),
         extrinsicSigner,
         extrinsic.signature.toString(),
+        extrinsicEvents.length,
         args,
         error,
         BigInt(extrinsic.tip.toString()),

--- a/indexers/db/docker-entrypoint-initdb.d/init-db.sql
+++ b/indexers/db/docker-entrypoint-initdb.d/init-db.sql
@@ -388,6 +388,7 @@ CREATE TABLE consensus.extrinsics (
     nonce NUMERIC NOT NULL,
     signer TEXT NOT NULL,
     signature TEXT NOT NULL,
+    events_count INTEGER NOT NULL,
     args JSONB NOT NULL,
     error TEXT NOT NULL,
     tip NUMERIC NOT NULL,


### PR DESCRIPTION
## Add an eventscount to the consensusextrinsics table and logic to indexer

This will allow to not need to query aggregate count inside the extrinsic details query