### PR TITLE
Improve leaderboard indexer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,13 +276,10 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
-      dictionary_subquery_node:
-        condition: service_healthy
     restart: unless-stopped
     environment:
       ENDPOINT: ${RPC_URLS}
       CHAIN_ID: ${CHAIN_ID}
-      DICTIONARY: ${DICTIONARY_URL}
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASSWORD}
       DB_DATABASE: ${DB_DATABASE}

--- a/indexers/leaderboard/project.ts
+++ b/indexers/leaderboard/project.ts
@@ -40,7 +40,6 @@ const project: SubstrateProject = {
      * These settings can be found in your docker-compose.yaml, they will slow indexing but prevent your project being rate limited
      */
     endpoint: process.env.RPC_URLS!?.split(",") as string[] | string,
-    dictionary: process.env.DICTIONARY_URL!,
   },
   dataSources: [
     {

--- a/indexers/leaderboard/src/mappings/db.ts
+++ b/indexers/leaderboard/src/mappings/db.ts
@@ -25,7 +25,7 @@ import {
   OperatorWithdrawalsTotalCountHistory,
 } from "../types";
 
-type Cache = {
+export type Cache = {
   accountExtrinsicFailedTotalCountHistory: AccountExtrinsicFailedTotalCountHistory[];
   accountExtrinsicSuccessTotalCountHistory: AccountExtrinsicSuccessTotalCountHistory[];
   accountExtrinsicTotalCountHistory: AccountExtrinsicTotalCountHistory[];

--- a/indexers/leaderboard/src/mappings/eventHandler.ts
+++ b/indexers/leaderboard/src/mappings/eventHandler.ts
@@ -1,0 +1,407 @@
+import { EventRecord } from "@autonomys/auto-utils";
+import * as db from "./db";
+import { Cache } from "./db";
+
+type EventHandler = (params: {
+  event: EventRecord;
+  cache: Cache;
+  height: bigint;
+  timestamp: Date;
+  extrinsicId: string;
+  eventId: string;
+  extrinsic?: any;
+}) => void;
+
+export const EVENT_HANDLERS: Record<string, EventHandler> = {
+  "balances.Transfer": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const from = event.event.data[0].toString();
+    const to = event.event.data[1].toString();
+    const amount = BigInt(event.event.data[2].toString());
+
+    cache.accountTransferSenderTotalCountHistory.push(
+      db.createAccountTransferSenderTotalCount(
+        from,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.accountTransferSenderTotalValueHistory.push(
+      db.createAccountTransferSenderTotalValue(
+        from,
+        amount,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+
+    cache.accountTransferReceiverTotalCountHistory.push(
+      db.createAccountTransferReceiverTotalCount(
+        to,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.accountTransferReceiverTotalValueHistory.push(
+      db.createAccountTransferReceiverTotalValue(
+        to,
+        amount,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+  "transactionPayment.TransactionFeePaid": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const who = event.event.data[0].toString();
+    const actualFee = BigInt(event.event.data[1].toString());
+    const tip = BigInt(event.event.data[2].toString());
+
+    cache.accountTransactionFeePaidTotalValueHistory.push(
+      db.createAccountTransactionFeePaidTotalValue(
+        who,
+        actualFee + tip,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+  "domains.OperatorRewarded": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const operatorId = event.event.data[1].toString();
+    const reward = BigInt(event.event.data[1].toString());
+    if (reward === BigInt(0)) return;
+
+    cache.operatorTotalRewardsCollectedHistory.push(
+      db.createOperatorTotalRewardsCollected(
+        operatorId,
+        reward,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+  "domains.OperatorTaxCollected": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const operatorId = event.event.data[0].toString();
+    const tax = BigInt(event.event.data[1].toString());
+
+    cache.operatorTotalTaxCollectedHistory.push(
+      db.createOperatorTotalTaxCollected(
+        operatorId,
+        tax,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+  "domains.BundleStored": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const bundleAuthor = event.event.data[0].toString();
+
+    cache.operatorBundleTotalCountHistory.push(
+      db.createOperatorBundleTotalCount(
+        bundleAuthor,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+  "domains.OperatorRegistered": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+    extrinsic,
+  }) => {
+    const operatorId = event.event.data[1].toString();
+    const amount = BigInt(extrinsic.data[0].toString());
+    const nominatorId = extrinsic.signer.toString();
+
+    cache.operatorDepositsTotalCountHistory.push(
+      db.createOperatorDepositsTotalCount(
+        operatorId,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.operatorDepositsTotalValueHistory.push(
+      db.createOperatorDepositsTotalValue(
+        operatorId,
+        amount,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+
+    cache.nominatorDepositsTotalCountHistory.push(
+      db.createNominatorDepositsTotalCount(
+        nominatorId,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.nominatorDepositsTotalValueHistory.push(
+      db.createNominatorDepositsTotalValue(
+        nominatorId,
+        amount,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+  "domains.OperatorNominated": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const operatorId = event.event.data[0].toString();
+    const nominatorId = event.event.data[1].toString();
+    const amount = BigInt(event.event.data[2].toString());
+
+    cache.operatorDepositsTotalCountHistory.push(
+      db.createOperatorDepositsTotalCount(
+        operatorId,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.operatorDepositsTotalValueHistory.push(
+      db.createOperatorDepositsTotalValue(
+        operatorId,
+        amount,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+
+    cache.nominatorDepositsTotalCountHistory.push(
+      db.createNominatorDepositsTotalCount(
+        nominatorId,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.nominatorDepositsTotalValueHistory.push(
+      db.createNominatorDepositsTotalValue(
+        nominatorId,
+        amount,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+  "domains.WithdrewStake": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const operatorId = event.event.data[0].toString();
+    const nominatorId = event.event.data[1].toString();
+
+    cache.operatorWithdrawalsTotalCountHistory.push(
+      db.createOperatorWithdrawalsTotalCount(
+        operatorId,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.nominatorWithdrawalsTotalCountHistory.push(
+      db.createNominatorWithdrawalsTotalCount(
+        nominatorId,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+  // Finalization events
+  "rewards.VoteReward": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const voter = event.event.data[0].toString();
+    const reward = BigInt(event.event.data[1].toString());
+
+    cache.farmerVoteTotalCountHistory.push(
+      db.createFarmerVoteTotalCount(
+        voter,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.farmerVoteTotalValueHistory.push(
+      db.createFarmerVoteTotalValue(
+        voter,
+        reward,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+
+    cache.farmerVoteAndBlockTotalCountHistory.push(
+      db.createFarmerVoteAndBlockTotalCount(
+        voter,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.farmerVoteAndBlockTotalValueHistory.push(
+      db.createFarmerVoteAndBlockTotalValue(
+        voter,
+        reward,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+  "rewards.BlockReward": ({
+    event,
+    cache,
+    height,
+    timestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const blockAuthor = event.event.data[0].toString();
+    const reward = BigInt(event.event.data[1].toString());
+
+    cache.farmerBlockTotalCountHistory.push(
+      db.createFarmerBlockTotalCount(
+        blockAuthor,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.farmerBlockTotalValueHistory.push(
+      db.createFarmerBlockTotalValue(
+        blockAuthor,
+        reward,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+
+    cache.farmerVoteAndBlockTotalCountHistory.push(
+      db.createFarmerVoteAndBlockTotalCount(
+        blockAuthor,
+        BigInt(1),
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+    cache.farmerVoteAndBlockTotalValueHistory.push(
+      db.createFarmerVoteAndBlockTotalValue(
+        blockAuthor,
+        reward,
+        height,
+        extrinsicId,
+        eventId,
+        timestamp
+      )
+    );
+  },
+};

--- a/indexers/leaderboard/src/mappings/extrinsicHandler.ts
+++ b/indexers/leaderboard/src/mappings/extrinsicHandler.ts
@@ -1,0 +1,44 @@
+import { EventRecord } from "@autonomys/auto-utils";
+import * as db from "./db";
+import { Cache } from "./db";
+
+type ExtrinsicHandler = (params: {
+  extrinsicEvents: EventRecord[];
+  cache: Cache;
+  height: bigint;
+  timestamp: Date;
+  extrinsicId: string;
+  extrinsicSigner: string;
+  extrinsic?: any;
+}) => void;
+
+const handleRemark: ExtrinsicHandler = ({
+  extrinsicEvents,
+  cache,
+  height,
+  timestamp,
+  extrinsicId,
+  extrinsicSigner,
+}) => {
+  const eventRemarked = extrinsicEvents.find(
+    (e) => e.event.section === "system" && e.event.method === "Remarked"
+  );
+  const eventRemarkedId = eventRemarked
+    ? height + "-" + eventRemarked.event.index.toString()
+    : "";
+  cache.accountRemarkCountHistory.push(
+    db.createAccountRemarkCount(
+      extrinsicSigner,
+      BigInt(1),
+      height,
+      extrinsicId,
+      eventRemarkedId,
+      timestamp
+    )
+  );
+};
+
+export const EXTRINSIC_HANDLERS: Record<string, ExtrinsicHandler> = {
+  "system.remark": handleRemark,
+  "system.remarkWithEvent": handleRemark,
+};

--- a/indexers/leaderboard/tsconfig.json
+++ b/indexers/leaderboard/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "target": "es2017",
+    "lib": ["ES2023"],
     "strict": true
   },
   "include": [


### PR DESCRIPTION
## Improve leaderboard indexer

Use map to list event logic (eventsHandler) instead to use switch, this should reduce indexing speed, especially when a block has the same event more than ounce