### PR TITLE
Improve consensus indexer logic

### DIFF
--- a/indexers/consensus/src/mappings/constants.ts
+++ b/indexers/consensus/src/mappings/constants.ts
@@ -1,0 +1,5 @@
+export const ZERO_BIGINT = BigInt(0);
+
+export const PAD_ZEROS = "0".repeat(32);
+
+export const CONSENSUS_CHAIN_TYPE = "consensus";

--- a/indexers/consensus/src/mappings/db.ts
+++ b/indexers/consensus/src/mappings/db.ts
@@ -1,4 +1,34 @@
+import { Entity } from "@subql/types-core";
+import { ZERO_BIGINT } from "./constants";
 import { getSortId, moduleName } from "./utils";
+
+export type Cache = {
+  rewards: Entity[];
+  transfers: Entity[];
+
+  addressToUpdate: Set<string>;
+  // Totals
+  totalBlockRewardsCount: number;
+  totalVoteRewardsCount: number;
+  totalTransferValue: bigint;
+  totalRewardValue: bigint;
+  totalBlockRewardValue: bigint;
+  totalVoteRewardValue: bigint;
+};
+
+export const initializeCache = (): Cache => ({
+  rewards: [],
+  transfers: [],
+
+  addressToUpdate: new Set<string>(),
+  // Totals
+  totalBlockRewardsCount: 0,
+  totalVoteRewardsCount: 0,
+  totalTransferValue: ZERO_BIGINT,
+  totalRewardValue: ZERO_BIGINT,
+  totalBlockRewardValue: ZERO_BIGINT,
+  totalVoteRewardValue: ZERO_BIGINT,
+});
 
 // Core Consensus DB Functions
 

--- a/indexers/consensus/src/mappings/eventHandler.ts
+++ b/indexers/consensus/src/mappings/eventHandler.ts
@@ -1,0 +1,167 @@
+import { EventRecord } from "@autonomys/auto-utils";
+import { CONSENSUS_CHAIN_TYPE } from "./constants";
+import { Cache, createReward, createTransfer } from "./db";
+
+type EventHandler = (params: {
+  event: EventRecord;
+  cache: Cache;
+  height: bigint;
+  blockHash: string;
+  blockTimestamp: Date;
+  extrinsicId: string;
+  eventId: string;
+  extrinsic?: any;
+  fee: bigint;
+  successEvent: boolean;
+  extrinsicSigner: string;
+  extrinsicMethodToPrimitive: any;
+}) => void;
+
+export const EVENT_HANDLERS: Record<string, EventHandler> = {
+  "rewards.VoteReward": ({
+    event,
+    cache,
+    height,
+    blockHash,
+    blockTimestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const voter = event.event.data[0].toString();
+    const reward = BigInt(event.event.data[1].toString());
+
+    cache.addressToUpdate.add(voter);
+
+    cache.totalVoteRewardsCount++;
+    cache.totalRewardValue += reward;
+    cache.totalVoteRewardValue += reward;
+
+    cache.rewards.push(
+      createReward(
+        height,
+        blockHash,
+        extrinsicId,
+        eventId,
+        voter,
+        "rewards.VoteReward",
+        reward,
+        blockTimestamp
+      )
+    );
+  },
+  "rewards.BlockReward": ({
+    event,
+    cache,
+    height,
+    blockHash,
+    blockTimestamp,
+    extrinsicId,
+    eventId,
+  }) => {
+    const blockAuthor = event.event.data[0].toString();
+    const reward = BigInt(event.event.data[1].toString());
+
+    cache.addressToUpdate.add(blockAuthor);
+
+    cache.totalBlockRewardsCount++;
+    cache.totalRewardValue += reward;
+    cache.totalBlockRewardValue += reward;
+
+    cache.rewards.push(
+      createReward(
+        height,
+        blockHash,
+        extrinsicId,
+        eventId,
+        blockAuthor,
+        "rewards.BlockReward",
+        reward,
+        blockTimestamp
+      )
+    );
+  },
+  "balances.Deposit": ({ event, cache }) => {
+    cache.addressToUpdate.add(event.event.data[0].toString());
+  },
+  "balances.Transfer": ({
+    event,
+    cache,
+    height,
+    blockHash,
+    blockTimestamp,
+    extrinsicId,
+    eventId,
+    fee,
+    successEvent,
+  }) => {
+    const from = event.event.data[0].toString();
+    const to = event.event.data[1].toString();
+    const amount = BigInt(event.event.data[2].toString());
+
+    cache.addressToUpdate.add(from);
+    cache.addressToUpdate.add(to);
+
+    cache.totalTransferValue += amount;
+
+    const newTransfer = createTransfer(
+      height,
+      blockHash,
+      extrinsicId,
+      eventId,
+      from,
+      CONSENSUS_CHAIN_TYPE,
+      to,
+      CONSENSUS_CHAIN_TYPE,
+      amount,
+      fee,
+      successEvent ? true : false,
+      blockTimestamp
+    );
+    cache.transfers.push(newTransfer);
+  },
+  "transporter.OutgoingTransferInitiated": ({
+    event,
+    cache,
+    height,
+    blockHash,
+    blockTimestamp,
+    extrinsicId,
+    eventId,
+    extrinsicSigner,
+    fee,
+    successEvent,
+    extrinsicMethodToPrimitive,
+  }) => {
+    const [chainType, domainId] = Object.entries(
+      extrinsicMethodToPrimitive.args.dst_location.chainId
+    )[0] as [string, string | undefined];
+    const [_, to] = Object.entries(
+      extrinsicMethodToPrimitive.args.dst_location.accountId
+    )[0] as [string, string];
+    const amount = BigInt(extrinsicMethodToPrimitive.args.amount.toString());
+
+    cache.addressToUpdate.add(extrinsicSigner);
+    if (chainType === CONSENSUS_CHAIN_TYPE) cache.addressToUpdate.add(to);
+
+    cache.totalTransferValue += amount;
+
+    const newTransfer = createTransfer(
+      height,
+      blockHash,
+      extrinsicId,
+      eventId,
+      extrinsicSigner,
+      CONSENSUS_CHAIN_TYPE,
+      to,
+      chainType + ":" + domainId,
+      amount,
+      fee,
+      successEvent ? true : false,
+      blockTimestamp
+    );
+    cache.transfers.push(newTransfer);
+  },
+  "balances.Burned": ({ event, cache }) => {
+    cache.addressToUpdate.add(event.event.data[0].toString());
+  },
+};

--- a/indexers/consensus/src/mappings/utils.ts
+++ b/indexers/consensus/src/mappings/utils.ts
@@ -1,4 +1,5 @@
 import { capitalizeFirstLetter } from "@autonomys/auto-utils";
+import { PAD_ZEROS } from "./constants";
 
 export const decodeLog = (value: null | Uint8Array | Uint8Array[]) => {
   if (!value) return null;
@@ -17,16 +18,13 @@ export const moduleName = (section: string, method: string) =>
   `${capitalizeFirstLetter(section)}.${capitalizeFirstLetter(method)}`;
 
 export const getSortId = (
-  blockHeight: bigint,
-  indexInBlock?: bigint
+  blockHeight: bigint | string,
+  indexInBlock?: bigint | string
 ): string => {
-  const totalLength = 32;
-  const str1 = blockHeight.toString().padStart(totalLength, "0");
-
+  const str1 = blockHeight.toString().padStart(32, PAD_ZEROS);
   if (indexInBlock === undefined) return str1;
-
-  const str2 = indexInBlock.toString().padStart(totalLength, "0");
-  return `${str1}-${str2}`;
+  const str2 = indexInBlock.toString().padStart(32, PAD_ZEROS);
+  return str1 + "-" + str2;
 };
 
 export const hexToUint8Array = (hex: string): Uint8Array => {


### PR DESCRIPTION
## Improve consensus indexer logic

- Use map to list event logic (eventsHandler) instead to use switch, this should reduce indexing speed, especially when a block has the same event more than ounce
- Define more const (like BigInt(0))