### PR TITLE
improve pgcat and postgres connection handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       POSTGRES_DB: ${DB_DATABASE}
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_MAX_CONNECTIONS: 100
+      POSTGRES_MAX_CONNECTIONS: 500
       POSTGRES_HOST_AUTH_METHOD: md5
       POSTGRES_INITDB_ARGS: --auth=md5
     ports:
@@ -118,8 +118,6 @@ services:
   hasura:
     image: hasura/graphql-engine:v2.40.0
     depends_on:
-      pgcat:
-        condition: service_healthy
       postgres:
         condition: service_healthy
     volumes:
@@ -128,8 +126,8 @@ services:
     restart: unless-stopped
     environment:
       # Essential Environment Variables
-      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@pgcat:6432/${DB_DATABASE}
-      HASURA_GRAPHQL_DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@pgcat:6432/${DB_DATABASE} # Main database connection
+      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_DATABASE}
+      HASURA_GRAPHQL_DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_DATABASE} # Main database connection
       HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET} # Admin access secret
       HASURA_GRAPHQL_JWT_SECRET: ${HASURA_GRAPHQL_JWT_SECRET} # JWT authentication secret
 

--- a/indexers/db/pgcat.toml
+++ b/indexers/db/pgcat.toml
@@ -17,6 +17,9 @@ enable_prometheus_exporter = true
 # Port at which prometheus exporter listens on.
 prometheus_exporter_port = 9930
 
+# The number of Tokio worker threads to launch. This should match the number of CPU cores available.
+worker_threads = 16
+
 # How long to wait before aborting a server connection (ms).
 connect_timeout = 10000
 
@@ -56,7 +59,7 @@ admin_password = "postgres"
 # Pool mode (see PgBouncer docs for more).
 # session: one server connection per connected client
 # transaction: one server connection per client transaction
-pool_mode = "session"
+pool_mode = "transaction"
 
 # If the client doesn't specify, route traffic to
 # this role by default.
@@ -73,7 +76,7 @@ password = "postgres"
 # Maximum number of server connections that can be established for this user
 # The maximum number of connection from a single Pgcat process to any database in the cluster
 # is the sum of pool_size across all users.
-pool_size = 30
+pool_size = 100
 
 # Maximum query duration. Dangerous, but protects against DBs that died in a non-obvious way.
 statement_timeout = 0


### PR DESCRIPTION
improve pgcat and postgres connection handling:
- increase pool size `pool_size` to 100
- increase `worker_threads` to 16
- use `transaction` for `pool_mode` (this offers better performance and connection reuse).
- change hasura to use bypass pgcat and use postgres directly since it doesn't work with transaction pool mode