### PR TITLE
feat(ui): ✨ Home card skeleton with data hydration

### DIFF
--- a/explorer/src/components/Consensus/Home/HomeChainInfo.tsx
+++ b/explorer/src/components/Consensus/Home/HomeChainInfo.tsx
@@ -1,5 +1,5 @@
+import HomeInfoCardSkeleton from '@/components/common/HomeInfoCardSkeleton'
 import { formatSpaceToDecimal } from '@autonomys/auto-consensus'
-import { Spinner } from 'components/common/Spinner'
 import type { HomeQuery } from 'gql/graphql'
 import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
@@ -129,40 +129,42 @@ export const HomeChainInfo: FC<Props> = ({ data, loading }) => {
   }, [])
 
   return (
-    <>
-      {!data || loading ? (
-        <Spinner isXSmall />
-      ) : (
-        <Swiper
-          slidesPerView={1}
-          spaceBetween={20}
-          pagination={{
-            clickable: true,
-            renderBullet: (index, className) =>
-              `<span class="${className}" style="background-color: #1949D2;"></span>`,
-          }}
-          breakpoints={{
-            460: {
-              slidesPerView: 2,
-              spaceBetween: 20,
-            },
-            768: {
-              slidesPerView: 3,
-              spaceBetween: 20,
-            },
-            1024: {
-              slidesPerView: 4,
-              spaceBetween: 20,
-            },
-            1536: {
-              slidesPerView: 6,
-              spaceBetween: 20,
-            },
-          }}
-          modules={[Pagination]}
-          className={cn('flex w-full items-center', isDesktop ? 'mb-12 !p-0' : 'mb-4 !pb-10')}
-        >
-          {listOfCards.map(({ title, value, imagePath, darkBgClass }, index) => (
+    <Swiper
+      slidesPerView={1}
+      spaceBetween={20}
+      pagination={{
+        clickable: true,
+        renderBullet: (index, className) =>
+          `<span key="${index}" class="${className}" style="background-color: #1949D2;"></span>`,
+      }}
+      breakpoints={{
+        460: {
+          slidesPerView: 2,
+          spaceBetween: 20,
+        },
+        768: {
+          slidesPerView: 3,
+          spaceBetween: 20,
+        },
+        1024: {
+          slidesPerView: 4,
+          spaceBetween: 20,
+        },
+        1536: {
+          slidesPerView: 6,
+          spaceBetween: 20,
+        },
+      }}
+      modules={[Pagination]}
+      className={cn('flex w-full items-center', isDesktop ? 'mb-12 !p-0' : 'mb-4 !pb-10')}
+    >
+      {!data || loading
+        ? Array.from({ length: 6 }).map((_, index) => (
+            <SwiperSlide key={`loader-${index}`}>
+              <HomeInfoCardSkeleton key={index} />
+            </SwiperSlide>
+          ))
+        : listOfCards.map(({ title, value, imagePath, darkBgClass }, index) => (
             <SwiperSlide key={`${title}-${index}`}>
               <HomeInfoCard
                 title={title}
@@ -172,8 +174,6 @@ export const HomeChainInfo: FC<Props> = ({ data, loading }) => {
               />
             </SwiperSlide>
           ))}
-        </Swiper>
-      )}
-    </>
+    </Swiper>
   )
 }

--- a/explorer/src/components/Consensus/Home/HomeChainInfoExtra.tsx
+++ b/explorer/src/components/Consensus/Home/HomeChainInfoExtra.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@/components/common/Spinner'
+import HomeInfoCardSkeleton from '@/components/common/HomeInfoCardSkeleton'
 import useMediaQuery from '@/hooks/useMediaQuery'
 import { cn } from '@/utils/cn'
 import type { HomeQuery } from 'gql/graphql'
@@ -73,40 +73,46 @@ export const HomeChainInfoExtra: FC<Props> = ({ data, loading }) => {
   )
 
   return (
-    <>
-      {!data || loading ? (
-        <Spinner isXSmall />
-      ) : (
-        <Swiper
-          slidesPerView={1}
-          spaceBetween={20}
-          pagination={{
-            clickable: true,
-            renderBullet: (index, className) =>
-              `<span class="${className}" style="background-color: #1949D2;"></span>`,
-          }}
-          breakpoints={{
-            460: {
-              slidesPerView: 2,
-              spaceBetween: 20,
-            },
-            768: {
-              slidesPerView: 3,
-              spaceBetween: 20,
-            },
-            1024: {
-              slidesPerView: 4,
-              spaceBetween: 20,
-            },
-            1536: {
-              slidesPerView: 5,
-              spaceBetween: 20,
-            },
-          }}
-          modules={[Pagination]}
-          className={cn('flex w-full items-center gap-5', isDesktop ? '!p-0' : '!pb-10')}
-        >
-          {listOfCards.map(({ title, value, darkBgClass }, index) => (
+    <Swiper
+      slidesPerView={1}
+      spaceBetween={20}
+      pagination={{
+        clickable: true,
+        renderBullet: (index, className) =>
+          `<span class="${className}" style="background-color: #1949D2;"></span>`,
+      }}
+      breakpoints={{
+        460: {
+          slidesPerView: 2,
+          spaceBetween: 20,
+        },
+        768: {
+          slidesPerView: 3,
+          spaceBetween: 20,
+        },
+        1024: {
+          slidesPerView: 4,
+          spaceBetween: 20,
+        },
+        1536: {
+          slidesPerView: 5,
+          spaceBetween: 20,
+        },
+      }}
+      modules={[Pagination]}
+      className={cn('flex w-full items-center gap-5', isDesktop ? '!p-0' : '!pb-10')}
+    >
+      {!data || loading
+        ? Array.from({ length: 5 }).map((_, index) => (
+            <SwiperSlide key={`loader-${index}`}>
+              <HomeInfoCardSkeleton
+                key={index}
+                className='h-[120px]'
+                imagePlaceholderClassName='hidden'
+              />
+            </SwiperSlide>
+          ))
+        : listOfCards.map(({ title, value, darkBgClass }, index) => (
             <SwiperSlide key={`${title}-${index}`}>
               <HomeInfoCard
                 key={`${title}-${index}`}
@@ -116,8 +122,6 @@ export const HomeChainInfoExtra: FC<Props> = ({ data, loading }) => {
               />
             </SwiperSlide>
           ))}
-        </Swiper>
-      )}
-    </>
+    </Swiper>
   )
 }

--- a/explorer/src/components/common/HomeInfoCardSkeleton.tsx
+++ b/explorer/src/components/common/HomeInfoCardSkeleton.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/utils/cn'
+import React from 'react'
+
+export type HomeInfoCardSkeletonProps = {
+  className?: string
+  imagePlaceholderClassName?: string
+}
+
+const HomeInfoCardSkeleton = ({
+  className,
+  imagePlaceholderClassName,
+}: HomeInfoCardSkeletonProps) => {
+  return (
+    <div className={cn('h-[216px] w-full min-w-[200px] grow md:min-w-[228px]', className)}>
+      <div className='flex h-full flex-col justify-center rounded-[20px] bg-white dark:bg-boxDark'>
+        {/* Image/Icon placeholder */}
+        <div
+          className={cn(
+            'mb-2 flex w-full items-center justify-center align-middle',
+            imagePlaceholderClassName,
+          )}
+        >
+          <div className='m-2 h-[84px] w-[84px] animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700' />
+        </div>
+
+        {/* Title placeholder */}
+        <div className='flex w-full flex-col items-center justify-center'>
+          <div className='mb-3 h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700' />
+          {/* Value placeholder */}
+          <div className='h-7 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700' />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default HomeInfoCardSkeleton


### PR DESCRIPTION
- [x] Home card skeleton
- [ ] add some animation that count up between the 2 different numbers as the data get refresh

------

### Light Mode
![Screenshot 2025-02-07 033716](https://github.com/user-attachments/assets/6aea5a88-9015-4262-84a9-bd8aecdf1f0c)
![Screenshot 2025-02-07 033805](https://github.com/user-attachments/assets/ed9f185d-8ea4-482f-a8d4-18c6e570743f)

### Dark Mode

![Screenshot 2025-02-07 033727](https://github.com/user-attachments/assets/f69dca70-9643-4b51-952e-3b17009f3173)
![Screenshot 2025-02-07 033754](https://github.com/user-attachments/assets/72c5accc-ce0b-4c8b-b15c-4af1fb9d0f66)

