### PR TITLE
feat(ui): ✨ tooltip implementation with create portal

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -34,6 +34,7 @@
     "@autonomys/auto-consensus": "^1.2.5",
     "@autonomys/auto-drive": "^1.2.5",
     "@autonomys/auto-utils": "^1.2.5",
+    "@floating-ui/react": "^0.27.4",
     "@headlessui/react": "^1.7.18",
     "@headlessui/tailwindcss": "^0.2.0",
     "@heroicons/react": "^2.1.1",

--- a/explorer/src/components/Domain/DomainsList.tsx
+++ b/explorer/src/components/Domain/DomainsList.tsx
@@ -77,7 +77,7 @@ export const DomainsList: FC = () => {
                   Details: {row.original.runtimeInfo}
                 </span>
               }
-              direction='left'
+              direction='bottom'
               className='max-w-[650px]'
             >
               <div>{capitalizeFirstLetter(row.original.name)}</div>

--- a/explorer/src/components/Domain/DomainsList.tsx
+++ b/explorer/src/components/Domain/DomainsList.tsx
@@ -77,7 +77,8 @@ export const DomainsList: FC = () => {
                   Details: {row.original.runtimeInfo}
                 </span>
               }
-              direction='bottom'
+              direction='left'
+              className='max-w-[650px]'
             >
               <div>{capitalizeFirstLetter(row.original.name)}</div>
             </Tooltip>

--- a/explorer/yarn.lock
+++ b/explorer/yarn.lock
@@ -1322,6 +1322,42 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.9.tgz#64d1da251433019dafa091de9b2886ff35ec14e6"
+  integrity sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==
+  dependencies:
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/dom@^1.0.0":
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.13.tgz#a8a938532aea27a95121ec16e667a7cbe8c59e34"
+  integrity sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/react-dom@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
+  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
+"@floating-ui/react@^0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.4.tgz#283ceaa8539282d6b8e6a84ac0400c111bee1e7a"
+  integrity sha512-05mXdkUiVh8NCEcYKQ2C9SV9IkZ9k/dFtYmaEIN2riLv80UHoXylgBM76cgPJYfLJM3dJz7UE5MOVH0FypMd2Q==
+  dependencies:
+    "@floating-ui/react-dom" "^2.1.2"
+    "@floating-ui/utils" "^0.2.9"
+    tabbable "^6.0.0"
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
+
 "@graphql-codegen/add@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/add/-/add-5.0.3.tgz#1ede6bac9a93661ed7fa5808b203d079e1b1d215"
@@ -9853,6 +9889,11 @@ synckit@^0.8.6:
   dependencies:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
+
+tabbable@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
 
 tailwind-datepicker-react@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
Closes: #1179 

This kind of issue happens when the `parent` component have `overflow` property in the element, and from that reason `z-index` and `position` fails to get applied to the child element.

Normally happens with the component which commonly have `z-index` 

- Tooltip
- Dropdown
- Model

To overcome these kind of issue `React` provide a hook called `createPortal`, which attach it to `<body>` instead of keeping it inside the `parent` element

```
/// main body element
<div id='root'>

</div>

----> Portal open the element here
```

#### References
- https://react.dev/reference/react-dom/createPortal


## All combination

### Top
![Screenshot 2025-02-10 005803](https://github.com/user-attachments/assets/605de6a9-3468-43d7-8b1f-a876e6a6ba87)
![Screenshot 2025-02-10 005623](https://github.com/user-attachments/assets/7979f711-b363-41fd-b3d5-3e20e1d4f41f)

### Bottom
![Screenshot 2025-02-10 005553](https://github.com/user-attachments/assets/27255249-48b5-48f6-8fbc-e440b6219f05)
![Screenshot 2025-02-10 005742](https://github.com/user-attachments/assets/a6512e31-efe1-4b0d-b19b-b13a87ea8673)

### Left
![Screenshot 2025-02-10 005648](https://github.com/user-attachments/assets/61e51e0c-b58c-4c33-8d2d-b36af0b3f24f)

### Right
![Screenshot 2025-02-10 005709](https://github.com/user-attachments/assets/8cbcf356-31a8-473b-b68b-272a4e84f0f1)

