### PR TITLE
update taurus blockscout link

### DIFF
--- a/explorer/src/components/common/EvmExplorerBanner.tsx
+++ b/explorer/src/components/common/EvmExplorerBanner.tsx
@@ -4,7 +4,7 @@ import React, { FC, useMemo } from 'react'
 
 export const EvmExplorerBanner: FC<{ path?: string }> = ({ path }) => {
   const href = useMemo(
-    () => (path ? EXTERNAL_ROUTES.novaExplorer + path : EXTERNAL_ROUTES.novaExplorer),
+    () => (path ? EXTERNAL_ROUTES.taurusEvmExplorer + path : EXTERNAL_ROUTES.taurusEvmExplorer),
     [path],
   )
   return (

--- a/explorer/src/constants/routes.ts
+++ b/explorer/src/constants/routes.ts
@@ -188,7 +188,7 @@ export const EXTERNAL_ROUTES = {
     linkedin: 'https://www.linkedin.com/company/autonomys/',
     subSocial: 'https://app.subsocial.network/@NetworkSubspace',
   },
-  novaExplorer: 'https://nova.subspace.network/',
+  taurusEvmExplorer: 'https://blockscout.taurus.autonomys.xyz/',
   polkadot: (network: NetworkId): string =>
     `https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.${network}.subspace.network%2Fws#/explorer`,
   subscan: 'https://autonomys.subscan.io/',


### PR DESCRIPTION
This pull request includes updates to the EVM Explorer routes in the codebase. The primary change is the replacement of the `novaExplorer` route with the new `taurusEvmExplorer` route.

Key changes include:

* Updated the `EvmExplorerBanner` component to use the new `taurusEvmExplorer` route instead of the old `novaExplorer` route. (`explorer/src/components/common/EvmExplorerBanner.tsx`)
* Modified the `EXTERNAL_ROUTES` constant to replace the `novaExplorer` URL with the `taurusEvmExplorer` URL. (`explorer/src/constants/routes.ts`)