### PR TITLE
refactor(ui): 🔨 Replace the small serif font on the Home card and other places wherever it is used

### DIFF
--- a/explorer/tailwind.config.ts
+++ b/explorer/tailwind.config.ts
@@ -233,7 +233,7 @@ const config: Config = {
           fontWeight: '300',
         },
         h2: {
-          fontFamily: 'var(--font-roboto-serif), serif',
+          fontFamily: 'var(--font-libre-franklin), sans-serif',
           fontSize: '2.938rem',
           lineHeight: '120%',
           letterSpacing: '-0.02em',


### PR DESCRIPTION
closes: #1133 

## Before

![Screenshot 2025-02-12 000848](https://github.com/user-attachments/assets/c2db44be-1958-4cc7-bbdb-e2ca18fc7625)
![Screenshot 2025-02-12 000837](https://github.com/user-attachments/assets/ed5a4f0c-2e68-4206-9059-7bb2e05946b5)

## After
![Screenshot 2025-02-12 000727](https://github.com/user-attachments/assets/54a82df2-b77b-4796-831c-fd5d0869c2ca)
![Screenshot 2025-02-12 000740](https://github.com/user-attachments/assets/6f66f612-e451-4e81-8a3d-60fbbf8500ec)
![Screenshot 2025-02-12 000801](https://github.com/user-attachments/assets/93558e30-c18a-4704-9265-1bf683fbb3f1)
![Screenshot 2025-02-12 000749](https://github.com/user-attachments/assets/6aed2368-0c98-45e9-acba-3dfbf6f4945b)




