### PR TITLE
Fix op.id in trigger for OperatorDeregistration

### DIFF
--- a/indexers/db/docker-entrypoint-initdb.d/init-db.sql
+++ b/indexers/db/docker-entrypoint-initdb.d/init-db.sql
@@ -3085,7 +3085,7 @@ CREATE OR REPLACE FUNCTION staking.update_operator_on_deregistration() RETURNS T
 BEGIN
     UPDATE staking.operators
     SET 
-        status = 'DEREGISTERED',
+        raw_status = 'DEREGISTERED',
         updated_at = NEW.block_height
     WHERE id = NEW.id;
 

--- a/indexers/db/docker-entrypoint-initdb.d/init-db.sql
+++ b/indexers/db/docker-entrypoint-initdb.d/init-db.sql
@@ -3087,7 +3087,7 @@ BEGIN
     SET 
         status = 'DEREGISTERED',
         updated_at = NEW.block_height
-    WHERE id = NEW.operator_id;
+    WHERE id = NEW.id;
 
     RETURN NEW;
 END;


### PR DESCRIPTION
## Fix op.id in trigger for OperatorDeregistration

I was using OperatorDeregistration.operatorId in the trigger but this field does not exist the operator_id is actually the id (since the same op can't deregister multiple time anyway)