### PR TITLE
Fix add domain id to deposit history and fix nominator

### DIFF
--- a/indexers/db/docker-entrypoint-initdb.d/init-db.sql
+++ b/indexers/db/docker-entrypoint-initdb.d/init-db.sql
@@ -1206,6 +1206,7 @@ ALTER TABLE staking.deposit_events OWNER TO postgres;
 
 CREATE TABLE staking.deposit_histories (
     id text NOT NULL,
+    domain_id text NOT NULL,
     account_id text NOT NULL,
     operator_id text NOT NULL,
     nominator_id text NOT NULL,

--- a/indexers/staking/schema.graphql
+++ b/indexers/staking/schema.graphql
@@ -182,6 +182,7 @@ type OperatorStakingHistory @entity {
 
 type DepositHistory @entity {
   id: ID!
+  domainId: String!
   accountId: String!
   operatorId: String!
   nominatorId: String!

--- a/indexers/staking/src/mappings/db.ts
+++ b/indexers/staking/src/mappings/db.ts
@@ -15,7 +15,7 @@ import {
   WithdrawEvent,
   WithdrawalHistory,
 } from "../types";
-import { getSortId } from "./utils";
+import { getNominationId, getSortId } from "./utils";
 
 export type Cache = {
   bundleSubmission: BundleSubmission[];
@@ -158,12 +158,12 @@ export function createDepositEvent(
   eventId: string
 ): DepositEvent {
   return DepositEvent.create({
-    id: extrinsicId + "-" + accountId + "-" + domainId + "-" + operatorId,
+    id: extrinsicId + "-" + getNominationId(accountId, domainId, operatorId),
     sortId: getSortId(blockHeight, extrinsicId),
     accountId,
     domainId,
     operatorId,
-    nominatorId: accountId + "-" + domainId + "-" + operatorId,
+    nominatorId: getNominationId(accountId, domainId, operatorId),
     amount,
     storageFeeDeposit,
     totalAmount,
@@ -188,12 +188,12 @@ export function createWithdrawEvent(
   eventId: string
 ): WithdrawEvent {
   return WithdrawEvent.create({
-    id: extrinsicId + "-" + accountId + "-" + domainId + "-" + operatorId,
+    id: extrinsicId + "-" + getNominationId(accountId, domainId, operatorId),
     sortId: getSortId(blockHeight, extrinsicId),
     accountId,
     domainId,
     operatorId,
-    nominatorId: accountId + "-" + domainId + "-" + operatorId,
+    nominatorId: getNominationId(accountId, domainId, operatorId),
     toWithdraw,
     amount1,
     amount2,
@@ -260,7 +260,7 @@ export function createUnlockedEvent(
     domainId,
     operatorId,
     accountId,
-    nominatorId: accountId + "-" + operatorId,
+    nominatorId: getNominationId(accountId, domainId, operatorId),
     amount,
     storageFee,
     blockHeight,
@@ -409,6 +409,7 @@ export function createOperatorStakingHistory(
 
 export function createDepositHistory(
   hash: string,
+  domainId: string,
   accountId: string,
   operatorId: string,
   shares: bigint,
@@ -423,9 +424,10 @@ export function createDepositHistory(
 ): DepositHistory {
   return DepositHistory.create({
     id: hash,
+    domainId,
     accountId,
     operatorId,
-    nominatorId: accountId + "-" + operatorId,
+    nominatorId: getNominationId(accountId, domainId, operatorId),
     shares,
     storageFeeDeposit,
     sharesKnown,
@@ -455,7 +457,7 @@ export function createWithdrawalHistory(
     domainId,
     accountId,
     operatorId,
-    nominatorId: accountId + "-" + operatorId,
+    nominatorId: getNominationId(accountId, domainId, operatorId),
     totalWithdrawalAmount,
     domainEpoch,
     unlockAtConfirmedDomainBlockNumber,

--- a/indexers/staking/src/mappings/mappingHandlers.ts
+++ b/indexers/staking/src/mappings/mappingHandlers.ts
@@ -114,11 +114,18 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
   ).flat();
   deposits.forEach((d: any) => {
     const data = parseDeposit(d);
+    const operatorId = data.operatorId.toString();
+    const opFromCache = cache.operatorStakingHistory.find(
+      (o) => o.operatorId === operatorId
+    );
+    if (!opFromCache) throw new Error("Operator from cache not found");
+    const domainId = opFromCache.currentDomainId;
     cache.depositHistory.push(
       db.createDepositHistory(
         createHashId(data),
+        domainId,
         data.account,
-        data.operatorId.toString(),
+        operatorId,
         data.shares,
         data.storageFeeDeposit,
         data.known.shares,
@@ -143,14 +150,18 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
 
   withdrawals.forEach((w: any) => {
     const data = parseWithdrawal(w);
+    const operatorId = data.operatorId.toString();
+    const opFromCache = cache.operatorStakingHistory.find(
+      (o) => o.operatorId === operatorId
+    );
+    if (!opFromCache) throw new Error("Operator from cache not found");
+    const domainId = opFromCache.currentDomainId;
     cache.withdrawalHistory.push(
       db.createWithdrawalHistory(
         createHashId(data),
-        data.withdrawalInShares === null
-          ? ""
-          : data.withdrawalInShares.domainEpoch[0].toString(),
+        domainId,
         data.account,
-        data.operatorId.toString(),
+        operatorId,
         data.totalWithdrawalAmount,
         data.withdrawalInShares === null
           ? 0

--- a/indexers/staking/src/mappings/utils.ts
+++ b/indexers/staking/src/mappings/utils.ts
@@ -13,6 +13,12 @@ export const getSortId = (
   return str1 + "-" + str2;
 };
 
+export const getNominationId = (
+  accountId: string,
+  domainId: string,
+  operatorId: string
+): string => accountId + "-" + domainId + "-" + operatorId;
+
 export const createHashId = (data: any): string =>
   createHash("sha256").update(stringify(data)).digest("hex");
 


### PR DESCRIPTION
## Fix add domain id to deposit history and fix nominator

- Some tables were using wrong format for nominator id (it shoulld be accountId-domainId-operatorId making empty relation
- deposit history table did not had any domain id field