### PR TITLE
Query the parent hash operators and assign to the cache to have a fall back when looking for domainId

### DIFF
--- a/indexers/staking/src/mappings/db.ts
+++ b/indexers/staking/src/mappings/db.ts
@@ -1,3 +1,4 @@
+import { Operator } from "@autonomys/auto-consensus";
 import {
   BundleSubmission,
   DepositEvent,
@@ -33,6 +34,8 @@ export type Cache = {
   withdrawEvent: WithdrawEvent[];
   withdrawalHistory: WithdrawalHistory[];
   unlockedEvent: UnlockedEvent[];
+  // only for caching purposes
+  parentBlockOperators: Operator[];
 };
 
 export const initializeCache = (): Cache => ({
@@ -51,6 +54,8 @@ export const initializeCache = (): Cache => ({
   withdrawEvent: [],
   withdrawalHistory: [],
   unlockedEvent: [],
+  // only for caching purposes
+  parentBlockOperators: [],
 });
 
 export const saveCache = async (cache: Cache) => {

--- a/indexers/staking/src/mappings/eventHandler.ts
+++ b/indexers/staking/src/mappings/eventHandler.ts
@@ -289,11 +289,19 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     const operatorId = event.event.data[0].toString();
     const accountId = event.event.data[1].toString();
     const amount = BigInt(event.event.data[2].toString());
+    let domainId = null;
     const opFromCache = cache.operatorStakingHistory.find(
       (o) => o.operatorId === operatorId
     );
-    if (!opFromCache) throw new Error("Operator from cache not found");
-    const domainId = opFromCache.currentDomainId;
+    if (!opFromCache) {
+      const parentOpFromCache = cache.parentBlockOperators.find(
+        (o) => o.operatorId.toString() === operatorId
+      );
+      if (!parentOpFromCache) throw new Error("Operator from cache not found");
+      domainId = parentOpFromCache.operatorDetails.currentDomainId.toString();
+    } else {
+      domainId = opFromCache.currentDomainId;
+    }
 
     const StorageFeeUnlockedEvent = findOneExtrinsicEvent(
       extrinsicEvents,

--- a/indexers/staking/src/mappings/eventHandler.ts
+++ b/indexers/staking/src/mappings/eventHandler.ts
@@ -6,7 +6,11 @@ import {
 import * as db from "./db";
 import { Cache } from "./db";
 import { SealedBundleHeader } from "./types";
-import { calculateTransfer, findOneExtrinsicEvent } from "./utils";
+import {
+  calculateTransfer,
+  findDomainIdFromOperatorsCache,
+  findOneExtrinsicEvent,
+} from "./utils";
 
 type EventHandler = (params: {
   event: EventRecord;
@@ -144,6 +148,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     const operatorId = event.event.data[0].toString();
     const accountId = event.event.data[1].toString();
     const amount = BigInt(event.event.data[2].toString());
+    const domainId = findDomainIdFromOperatorsCache(cache, operatorId);
 
     const storageFeeDepositedEvent = findOneExtrinsicEvent(
       extrinsicEvents,
@@ -153,11 +158,6 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     const storageFeeDeposit = BigInt(
       storageFeeDepositedEvent?.event.data[2].toString() ?? 0
     );
-    const opFromCache = cache.operatorStakingHistory.find(
-      (o) => o.operatorId === operatorId
-    );
-    if (!opFromCache) throw new Error("Operator from cache not found");
-    const domainId = opFromCache.currentDomainId;
 
     cache.depositEvent.push(
       db.createDepositEvent(
@@ -201,11 +201,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     );
     const amount2 =
       amount1 - BigInt(amount2Event?.event.data[0].toString() ?? 0);
-    const opFromCache = cache.operatorStakingHistory.find(
-      (o) => o.operatorId === operatorId
-    );
-    if (!opFromCache) throw new Error("Operator from cache not found");
-    const domainId = opFromCache.currentDomainId;
+    const domainId = findDomainIdFromOperatorsCache(cache, operatorId);
 
     cache.withdrawEvent.push(
       db.createWithdrawEvent(
@@ -234,11 +230,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     const operatorId = event.event.data[1].toString();
     const amount = BigInt(event.event.data[2].toString());
     const atBlockNumber = BigInt(bundleDetails.bundle.atBlockNumber.toString());
-    const opFromCache = cache.operatorStakingHistory.find(
-      (o) => o.operatorId === operatorId
-    );
-    if (!opFromCache) throw new Error("Operator from cache not found");
-    const domainId = opFromCache.currentDomainId;
+    const domainId = findDomainIdFromOperatorsCache(cache, operatorId);
 
     cache.operatorReward.push(
       db.createOperatorReward(
@@ -261,11 +253,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
   }) => {
     const operatorId = event.event.data[0].toString();
     const tax = BigInt(event.event.data[1].toString());
-    const opFromCache = cache.operatorStakingHistory.find(
-      (o) => o.operatorId === operatorId
-    );
-    if (!opFromCache) throw new Error("Operator from cache not found");
-    const domainId = opFromCache.currentDomainId;
+    const domainId = findDomainIdFromOperatorsCache(cache, operatorId);
 
     cache.operatorTaxCollection.push(
       db.createOperatorTaxCollection(
@@ -289,19 +277,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     const operatorId = event.event.data[0].toString();
     const accountId = event.event.data[1].toString();
     const amount = BigInt(event.event.data[2].toString());
-    let domainId = null;
-    const opFromCache = cache.operatorStakingHistory.find(
-      (o) => o.operatorId === operatorId
-    );
-    if (!opFromCache) {
-      const parentOpFromCache = cache.parentBlockOperators.find(
-        (o) => o.operatorId.toString() === operatorId
-      );
-      if (!parentOpFromCache) throw new Error("Operator from cache not found");
-      domainId = parentOpFromCache.operatorDetails.currentDomainId.toString();
-    } else {
-      domainId = opFromCache.currentDomainId;
-    }
+    const domainId = findDomainIdFromOperatorsCache(cache, operatorId);
 
     const StorageFeeUnlockedEvent = findOneExtrinsicEvent(
       extrinsicEvents,
@@ -334,11 +310,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     eventId,
   }) => {
     const operatorId = event.event.data[0].toString();
-    const opFromCache = cache.operatorStakingHistory.find(
-      (o) => o.operatorId === operatorId
-    );
-    if (!opFromCache) throw new Error("Operator from cache not found");
-    const domainId = opFromCache.currentDomainId;
+    const domainId = findDomainIdFromOperatorsCache(cache, operatorId);
 
     cache.operatorDeregistration.push(
       db.createOperatorDeregistration(

--- a/indexers/staking/src/mappings/mappingHandlers.ts
+++ b/indexers/staking/src/mappings/mappingHandlers.ts
@@ -8,7 +8,7 @@ import { SubstrateBlock } from "@subql/types";
 import { SHARES_CALCULATION_MULTIPLIER, ZERO_BIGINT } from "./constants";
 import * as db from "./db";
 import { EVENT_HANDLERS } from "./eventHandler";
-import { createHashId } from "./utils";
+import { createHashId, findDomainIdFromOperatorsCache } from "./utils";
 
 export async function handleBlock(_block: SubstrateBlock): Promise<void> {
   const {
@@ -128,15 +128,10 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
   deposits.forEach((d: any) => {
     const data = parseDeposit(d);
     const operatorId = data.operatorId.toString();
-    const opFromCache = cache.operatorStakingHistory.find(
-      (o) => o.operatorId === operatorId
-    );
-    if (!opFromCache) throw new Error("Operator from cache not found");
-    const domainId = opFromCache.currentDomainId;
     cache.depositHistory.push(
       db.createDepositHistory(
         createHashId(data),
-        domainId,
+        findDomainIdFromOperatorsCache(cache, operatorId),
         data.account,
         operatorId,
         data.shares,
@@ -164,15 +159,10 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
   withdrawals.forEach((w: any) => {
     const data = parseWithdrawal(w);
     const operatorId = data.operatorId.toString();
-    const opFromCache = cache.operatorStakingHistory.find(
-      (o) => o.operatorId === operatorId
-    );
-    if (!opFromCache) throw new Error("Operator from cache not found");
-    const domainId = opFromCache.currentDomainId;
     cache.withdrawalHistory.push(
       db.createWithdrawalHistory(
         createHashId(data),
-        domainId,
+        findDomainIdFromOperatorsCache(cache, operatorId),
         data.account,
         operatorId,
         data.totalWithdrawalAmount,

--- a/indexers/staking/src/mappings/mappingHandlers.ts
+++ b/indexers/staking/src/mappings/mappingHandlers.ts
@@ -112,10 +112,9 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
     );
   });
 
-  parentBlockOperators.forEach((o: any) => {
-    const operator = parseOperator(o);
-    cache.parentBlockOperators.push(operator);
-  });
+  parentBlockOperators.forEach((o: any) =>
+    cache.parentBlockOperators.push(parseOperator(o))
+  );
 
   const deposits = (
     await Promise.all(

--- a/indexers/staking/src/mappings/mappingHandlers.ts
+++ b/indexers/staking/src/mappings/mappingHandlers.ts
@@ -33,7 +33,7 @@ export async function handleBlock(_block: SubstrateBlock): Promise<void> {
         )
       : api;
 
-  // Use to find the operator link to a the last unlock of a operator
+  // Use to query the parent block operators (for the last unlock of an operator (unlockNominator))
   const parentBlockApi = unsafeApi ? await unsafeApi.at(parentHash) : api;
 
   const [

--- a/indexers/staking/src/mappings/utils.ts
+++ b/indexers/staking/src/mappings/utils.ts
@@ -1,6 +1,7 @@
 import { EventRecord, stringify } from "@autonomys/auto-utils";
 import { createHash } from "crypto";
 import { PAD_ZEROS, ZERO_BIGINT } from "./constants";
+import { Cache } from "./db";
 import { Transfer } from "./types";
 
 export const getSortId = (
@@ -43,4 +44,21 @@ export const findOneExtrinsicEvent = (
       e.event.section === section &&
       e.event.method === method
   );
+};
+
+export const findDomainIdFromOperatorsCache = (
+  cache: Cache,
+  operatorId: string
+): string => {
+  const opFromCache = cache.operatorStakingHistory.find(
+    (o) => o.operatorId === operatorId
+  );
+  if (!opFromCache) {
+    const parentOpFromCache = cache.parentBlockOperators.find(
+      (o) => o.operatorId.toString() === operatorId
+    );
+    if (!parentOpFromCache) throw new Error("Operator from cache not found");
+    return parentOpFromCache.operatorDetails.currentDomainId.toString();
+  }
+  return opFromCache.currentDomainId;
 };


### PR DESCRIPTION
## Query the parent hash operators and assign to the cache to have a fall back when looking for domainId

I detected an edge case, when de-registering an operator, then unlocking the nominators. On the block of this event, the operator deregister disappears from the operators() states. Making finding the domainId of that operator from the current block cache impossible.

We need that domainId for the unlock event in db so this throw an error.

Workaround is to also query the parent hash operators and use this as fall back