### PR TITLE
Fix transfer count inside bundle

### DIFF
--- a/indexers/staking/src/mappings/types.ts
+++ b/indexers/staking/src/mappings/types.ts
@@ -54,13 +54,15 @@ interface InboxedBundle {
   extrinsicsRoot: Uint8Array;
 }
 
-export type Transfer = [ChainId, bigint];
+export type Transfer = {
+  [key: string]: bigint;
+};
 
 interface Transfers {
-  transfersIn: Transfer[];
-  transfersOut: Transfer[];
-  rejectedTransfersClaimed: Transfer[];
-  transfersRejected: Transfer[];
+  transfersIn: Transfer;
+  transfersOut: Transfer;
+  rejectedTransfersClaimed: Transfer;
+  transfersRejected: Transfer;
 }
 
 interface BlockFees {

--- a/indexers/staking/src/mappings/utils.ts
+++ b/indexers/staking/src/mappings/utils.ts
@@ -23,12 +23,12 @@ export const getNominationId = (
 export const createHashId = (data: any): string =>
   createHash("sha256").update(stringify(data)).digest("hex");
 
-export const calculateTransfer = (transfers: Transfer[]) => {
-  if (!Array.isArray(transfers)) return [ZERO_BIGINT, ZERO_BIGINT];
+export const calculateTransfer = (transfers: Transfer) => {
+  if (!transfers) return [ZERO_BIGINT, ZERO_BIGINT];
   let total = ZERO_BIGINT;
-  const length = transfers.length;
-  for (let i = 0; i < length; i++) {
-    total += BigInt(transfers[i][1]);
+  const length = Object.keys(transfers).length;
+  for (const key in transfers) {
+    total += BigInt(transfers[key]);
   }
   return [total, BigInt(length)];
 };


### PR DESCRIPTION
## Fix transfer count inside bundle

The transfer type has changed, it's now an object with the chain/domain name... and total, this will mean the transfer count is now useless.

We will also need to find a way to not double count the transfer at a domain level