### PR TITLE
Fix account list faulty where clause

### DIFF
--- a/explorer/src/components/Consensus/Account/AccountList.tsx
+++ b/explorer/src/components/Consensus/Account/AccountList.tsx
@@ -48,7 +48,8 @@ export const AccountList: FC = () => {
       ...availableColumns
         .filter((column) => column.searchable)
         .reduce((conditions, column) => {
-          const searchValue = `search-${column.name}` as keyof AccountsFilters
+          const searchKey = `search-${column.name}` as keyof AccountsFilters
+          const searchValue = filters[searchKey]
           return searchValue
             ? {
                 ...conditions,


### PR DESCRIPTION
## Fix account list faulty where clause

The logic to build the where clause on accountList was changed and was now creating a faulty where clase, returning a empty list