### PR TITLE
Fix url for cli in farming

### DIFF
--- a/explorer/src/components/layout/FarmingHeader.tsx
+++ b/explorer/src/components/layout/FarmingHeader.tsx
@@ -26,8 +26,8 @@ export const FarmingHeader = () => {
         link: `/${network}/${Routes.farming}`,
       },
       {
-        title: 'Advance CLI Documentation',
-        link: `${EXTERNAL_ROUTES.docs}farming/advanced-cli/install`,
+        title: 'CLI Documentation',
+        link: `${EXTERNAL_ROUTES.docs}farming/cli/install`,
       },
       {
         title: 'Space Acres Documentation',


### PR DESCRIPTION
## Fix url for cli in farming

The url for CLI documentation has change, so applying the change to Astral.