### PR TITLE
expose API and bullmq ports public

### DIFF
--- a/nginx/backend.conf
+++ b/nginx/backend.conf
@@ -1,6 +1,8 @@
 ## Rate-limit http requests to server
 limit_req_zone $binary_remote_addr zone=hasuralimit:10m rate=50r/s;
 limit_req_zone $binary_remote_addr zone=healthlimit:10m rate=3r/s;
+limit_req_zone $binary_remote_addr zone=apilimit:10m rate=100r/s;
+limit_req_zone $binary_remote_addr zone=bullmqlimit:10m rate=20r/s;
 
 map $http_upgrade $connection_upgrade {
   default upgrade;
@@ -13,12 +15,39 @@ server {
 
     server_name _;
 
+    #hasura
     location / {
         limit_req zone=hasuralimit burst=20 delay=10;
         limit_req_status 429;
         limit_req_log_level warn;
         proxy_buffering off;
         proxy_pass http://127.0.0.1:8080;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+    }
+
+    #api
+    location / {
+        limit_req zone=apilimit burst=50 nodelay;
+        limit_req_status 429;
+        limit_req_log_level warn;
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:3030;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+    }
+
+    #bullmq
+    location / {
+        limit_req zone=bullmqlimit burst=10 nodelay;
+        limit_req_status 429;
+        limit_req_log_level warn;
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:3020;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This PR exposes port 3030, this is the API I'll like to get end users to use.

Also exposing port 3020, this is our bullMQ dashboard, to give us more visibility on recurring tasks, (this one is protected by TLS + login + password)