### PR TITLE
Patch operator action since the status does not change as intended

### DIFF
--- a/explorer/src/components/Staking/OperatorsList.tsx
+++ b/explorer/src/components/Staking/OperatorsList.tsx
@@ -280,9 +280,15 @@ export const OperatorsList: FC<OperatorsListProps> = ({ domainId }) => {
               excludeActions.push(OperatorActionType.Deregister, OperatorActionType.UnlockNominator)
             if (row.original.status === OperatorStatus.PENDING_NEXT_EPOCH)
               excludeActions.push(OperatorActionType.Nominating)
-            if (row.original.status === OperatorStatus.ACTIVE)
+            if (
+              row.original.status === OperatorStatus.ACTIVE &&
+              !row.original.rawStatus.includes('deregistered')
+            )
               excludeActions.push(OperatorActionType.UnlockNominator)
-            if (row.original.status === OperatorStatus.DEREGISTERED)
+            if (
+              row.original.status === OperatorStatus.DEREGISTERED ||
+              row.original.rawStatus.includes('deregistered')
+            )
               excludeActions.push(OperatorActionType.Nominating, OperatorActionType.Deregister)
             if (row.original.status === OperatorStatus.SLASHED) return <></>
             const rowData = {


### PR DESCRIPTION
## Patch operator action since the status does not change as intended

The operator status stay ACTIVE in the entire life cycle of the OP, it should be switch to DEREGISTER and then UNLOCK and this create issue, I added a patch to use the raw status in the meanwhile