### PR TITLE
Fix: API routing for subql stack

### DIFF
--- a/nginx/backend.conf
+++ b/nginx/backend.conf
@@ -16,12 +16,12 @@ server {
     server_name _;
 
     #hasura
-    location / {
+    location ^~ / {
         limit_req zone=hasuralimit burst=20 delay=10;
         limit_req_status 429;
         limit_req_log_level warn;
         proxy_buffering off;
-        proxy_pass http://127.0.0.1:8080;
+        proxy_pass http://127.0.0.1:8080/;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -29,12 +29,12 @@ server {
     }
 
     #api
-    location /api {
+    location ^~ /api/ {
         limit_req zone=apilimit burst=50 nodelay;
         limit_req_status 429;
         limit_req_log_level warn;
         proxy_buffering off;
-        proxy_pass http://127.0.0.1:3030;
+        proxy_pass http://127.0.0.1:3030/;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -42,12 +42,12 @@ server {
     }
 
     #bullmq
-    location /bullmq {
+    location ^~ /bullmq/ {
         limit_req zone=bullmqlimit burst=10 nodelay;
         limit_req_status 429;
         limit_req_log_level warn;
         proxy_buffering off;
-        proxy_pass http://127.0.0.1:3020;
+        proxy_pass http://127.0.0.1:3020/;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
1- Use location blocks with exact or prefix matching that preserve subpaths.

2- Ensure proxy_pass forwards the full request URI to the upstream server.