### PR TITLE
Fix: Remove unneeded global prefix

### DIFF
--- a/indexers/api/src/main.ts
+++ b/indexers/api/src/main.ts
@@ -6,8 +6,6 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.setGlobalPrefix('api');
-
   app.enableCors({
     origin: true, // or specify origins like ['http://localhost:3000']
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',


### PR DESCRIPTION
## Fix: Remove unneeded global prefix

This pull request includes a small change to the `indexers/api/src/main.ts` file. The change removes the global prefix setting for the application.

* [`indexers/api/src/main.ts`](diffhunk://#diff-d39b415826fbff1756a31ec7e9e40897ba38badaa4fdb6f972ae452b5fc3887bL9-L10): Removed the line `app.setGlobalPrefix('api');` to eliminate the global prefix setting for the application.