### PR TITLE
Fix: Add multi-subdomain next-auth support

### DIFF
--- a/explorer/.env.sample
+++ b/explorer/.env.sample
@@ -1,6 +1,10 @@
+NODE_ENV='local'
+COOKIE_DOMAIN='localhost'
+
 # Next-Auth basic configuration
 NEXTAUTH_SECRET='secret-key-1234'
 NEXTAUTH_URL='http://localhost:3000'
+NEXTAUTH_SECONDARY_URL='https://astral.autonomys.xyz'
 
 FAUNA_DB_SECRET="<fauna-db-secret>"
 

--- a/explorer/src/utils/auth/authOptions.ts
+++ b/explorer/src/utils/auth/authOptions.ts
@@ -30,9 +30,27 @@ export const authOptions: AuthOptions = {
       }
       return token
     },
+    redirect: async ({ url, baseUrl }) => {
+      if (process.env.NEXTAUTH_URL && url.startsWith(process.env.NEXTAUTH_URL)) return url
+      if (process.env.NEXTAUTH_SECONDARY_URL && url.startsWith(process.env.NEXTAUTH_SECONDARY_URL))
+        return url
+      return baseUrl
+    },
     session: async ({ session, token }) => {
       if (token) session.user = token
       return session
+    },
+  },
+  cookies: {
+    sessionToken: {
+      name: 'next-auth.session-token',
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: process.env.NODE_ENV === 'production',
+        domain: process.env.COOKIE_DOMAIN || undefined,
+      },
     },
   },
 }


### PR DESCRIPTION
## Fix: Add multi-subdomain next-auth support

This pull request includes changes to enhance the authentication configuration in the `explorer` project. The most important changes involve updating environment variables and modifying the authentication options to support additional URLs and cookie settings.

Environment configuration:

* [`explorer/.env.sample`](diffhunk://#diff-26841996d8c65c716f75bed3864575a08123db2af68464927562482817bbd1eaR1-R7): Added `NODE_ENV`, `COOKIE_DOMAIN`, and `NEXTAUTH_SECONDARY_URL` environment variables.

Authentication options:

* [`explorer/src/utils/auth/authOptions.ts`](diffhunk://#diff-718aa391685d5b804b89364df621962d0e08eb43a321fd3d5c459e6bbc45ebb7R33-R55): Added a `redirect` method to handle redirection based on `NEXTAUTH_URL` and `NEXTAUTH_SECONDARY_URL`.
* [`explorer/src/utils/auth/authOptions.ts`](diffhunk://#diff-718aa391685d5b804b89364df621962d0e08eb43a321fd3d5c459e6bbc45ebb7R33-R55): Added cookie configuration to set the `sessionToken` with properties such as `httpOnly`, `sameSite`, `path`, `secure`, and `domain` based on the environment variables.