### PR TITLE
Fix: add rename for _id column on new tables

### DIFF
--- a/indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_blocks.yaml
+++ b/indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_blocks.yaml
@@ -1,6 +1,13 @@
 table:
   name: evm_blocks
   schema: domain_auto_evm
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 select_permissions:
   - role: user
     permission:

--- a/indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_code_selectors.yaml
+++ b/indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_code_selectors.yaml
@@ -1,6 +1,13 @@
 table:
   name: evm_code_selectors
   schema: domain_auto_evm
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 select_permissions:
   - role: user
     permission:

--- a/indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_codes.yaml
+++ b/indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_codes.yaml
@@ -1,6 +1,13 @@
 table:
   name: evm_codes
   schema: domain_auto_evm
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 select_permissions:
   - role: user
     permission:

--- a/indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_transactions.yaml
+++ b/indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_transactions.yaml
@@ -1,6 +1,13 @@
 table:
   name: evm_transactions
   schema: domain_auto_evm
+configuration:
+  column_config:
+    _id:
+      custom_name: uuid
+  custom_column_names:
+    _id: uuid
+  custom_root_fields: {}
 select_permissions:
   - role: user
     permission:


### PR DESCRIPTION
## Fix: add rename for _id column on new tables

This pull request includes changes to the configuration of several tables in the `domain_auto_evm` schema. The updates primarily involve adding custom column names and configurations to these tables.

Configuration updates:

* [`indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_blocks.yaml`](diffhunk://#diff-a4a2ca3269cd886f58f0fa2db3f890912bb075d1d4cf2b8a9a460ceed2732eeaR4-R10): Added configuration for custom column names, renaming `_id` to `uuid`.
* [`indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_code_selectors.yaml`](diffhunk://#diff-2b3e1e878691c6d7b7a1262488046cdefc8b1c4fab937cc406510777b312dda7R4-R10): Added configuration for custom column names, renaming `_id` to `uuid`.
* [`indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_codes.yaml`](diffhunk://#diff-63573f05ef122f6c2e5609ac235760138a02363f0cd090d2669ad93c4505bd4cR4-R10): Added configuration for custom column names, renaming `_id` to `uuid`.
* [`indexers/db/metadata/databases/default/tables/domain_auto_evm_evm_transactions.yaml`](diffhunk://#diff-e17e6085ab4ebe1b73c49de64e41858e25315a8bb52e63c6b8f9527ca27c1be0R4-R10): Added configuration for custom column names, renaming `_id` to `uuid`.