### PR TITLE
Fix: Replace extrinsicId for eventId in staking indexer id row

### DIFF
--- a/indexers/package.json
+++ b/indexers/package.json
@@ -8,7 +8,7 @@
     "*"
   ],
   "engines": {
-    "node": ">=20.8.0"
+    "node": ">=20.9.0"
   },
   "scripts": {
     "bootstrap": "lerna run bootstrap",

--- a/indexers/staking/src/mappings/db.ts
+++ b/indexers/staking/src/mappings/db.ts
@@ -162,7 +162,7 @@ export function createDepositEvent(
   eventId: string
 ): DepositEvent {
   return DepositEvent.create({
-    id: extrinsicId + "-" + getNominationId(accountId, domainId, operatorId),
+    id: eventId + "-" + getNominationId(accountId, domainId, operatorId),
     sortId: getSortId(blockHeight, extrinsicId),
     accountId,
     domainId,
@@ -193,7 +193,7 @@ export function createWithdrawEvent(
   eventId: string
 ): WithdrawEvent {
   return WithdrawEvent.create({
-    id: extrinsicId + "-" + getNominationId(accountId, domainId, operatorId),
+    id: eventId + "-" + getNominationId(accountId, domainId, operatorId),
     sortId: getSortId(blockHeight, extrinsicId),
     accountId,
     domainId,
@@ -220,7 +220,7 @@ export function createOperatorReward(
   eventId: string
 ): OperatorReward {
   return OperatorReward.create({
-    id: extrinsicId,
+    id: eventId,
     domainId,
     operatorId,
     amount,
@@ -240,7 +240,7 @@ export function createOperatorTaxCollection(
   eventId: string
 ): OperatorTaxCollection {
   return OperatorTaxCollection.create({
-    id: extrinsicId,
+    id: eventId,
     domainId,
     operatorId,
     amount,
@@ -261,7 +261,7 @@ export function createUnlockedEvent(
   eventId: string
 ): UnlockedEvent {
   return UnlockedEvent.create({
-    id: extrinsicId,
+    id: eventId,
     domainId,
     operatorId,
     accountId,
@@ -282,7 +282,7 @@ export function createNominatorsUnlockedEvent(
   eventId: string
 ): NominatorsUnlockedEvent {
   return NominatorsUnlockedEvent.create({
-    id: extrinsicId,
+    id: eventId,
     domainId,
     operatorId,
     blockHeight,


### PR DESCRIPTION
## Fix: Replace extrinsicId for eventId in staking indexer id row

This goes with [this discussion](https://discord.com/channels/864285291518361610/1166413895192281188/1353823091029049424)

This pull request includes updates to the `indexers` package to ensure consistency and correctness in event ID handling and node version requirements. The most important changes involve modifying the ID generation in various event creation functions and updating the node version requirement in the `package.json` file.

### Event ID Handling Updates:

* [`indexers/staking/src/mappings/db.ts`](diffhunk://#diff-73ef53457d65629fec0c5fe10974f6c60a5d354c8eac8f01c9e51309f64a1075L165-R165): Updated the `id` field in `createDepositEvent`, `createWithdrawEvent`, `createOperatorReward`, `createOperatorTaxCollection`, `createUnlockedEvent`, and `createNominatorsUnlockedEvent` functions to use `eventId` instead of `extrinsicId` for consistency and correctness. [[1]](diffhunk://#diff-73ef53457d65629fec0c5fe10974f6c60a5d354c8eac8f01c9e51309f64a1075L165-R165) [[2]](diffhunk://#diff-73ef53457d65629fec0c5fe10974f6c60a5d354c8eac8f01c9e51309f64a1075L196-R196) [[3]](diffhunk://#diff-73ef53457d65629fec0c5fe10974f6c60a5d354c8eac8f01c9e51309f64a1075L223-R223) [[4]](diffhunk://#diff-73ef53457d65629fec0c5fe10974f6c60a5d354c8eac8f01c9e51309f64a1075L243-R243) [[5]](diffhunk://#diff-73ef53457d65629fec0c5fe10974f6c60a5d354c8eac8f01c9e51309f64a1075L264-R264) [[6]](diffhunk://#diff-73ef53457d65629fec0c5fe10974f6c60a5d354c8eac8f01c9e51309f64a1075L285-R285)

### Node Version Requirement:

* [`indexers/package.json`](diffhunk://#diff-5a3170fcba4124815316964832355bdf480b83fd5ea1f4370fec88639793da81L11-R11): Updated the node version requirement from `>=20.8.0` to `>=20.9.0` to ensure compatibility with the latest features and security updates.