### PR TITLE
Hide all operator options after unlock nominators

### DIFF
--- a/explorer/src/components/Staking/NominationsTable.tsx
+++ b/explorer/src/components/Staking/NominationsTable.tsx
@@ -398,7 +398,11 @@ export const NominationsTable: FC = () => {
                                 OperatorActionType.Nominating,
                                 OperatorActionType.Deregister,
                               )
-                            if (nominator.operator?.status === OperatorStatus.SLASHED) return <></>
+                            if (
+                              nominator.operator?.status === OperatorStatus.SLASHED ||
+                              nominator.operator?.status === OperatorStatus.NOMINATORS_UNLOCKED
+                            )
+                              return <></>
                             return (
                               <OperatorActions
                                 handleAction={handleAction}


### PR DESCRIPTION
## Hide all operator options after unlock nominators

This pull request includes a modification to the `NominationsTable` component to handle an additional operator status condition.

Changes in `NominationsTable` component:

* [`explorer/src/components/Staking/NominationsTable.tsx`](diffhunk://#diff-ba8eca7d4b307e4d61732f10fb6d2f1c2e8c8fe7d4409a78c6724bddf75de2d2L401-R405): Updated the condition to check for both `OperatorStatus.SLASHED` and `OperatorStatus.NOMINATORS_UNLOCKED` statuses before returning an empty fragment.