### PR TITLE
Fix: Add a row in withdrawals when no row exists on unlock funds (unlockNominators edge case)

### DIFF
--- a/indexers/staking/schema.graphql
+++ b/indexers/staking/schema.graphql
@@ -134,6 +134,7 @@ type UnlockedEvent @entity {
   nominatorId: String!
   amount: BigInt!
   storageFee: BigInt!
+  timestamp: Date!
   blockHeight: BigInt!
   extrinsicId: String!
   eventId: String!

--- a/indexers/staking/src/mappings/db.ts
+++ b/indexers/staking/src/mappings/db.ts
@@ -256,6 +256,7 @@ export function createUnlockedEvent(
   accountId: string,
   amount: bigint,
   storageFee: bigint,
+  timestamp: Date,
   blockHeight: bigint,
   extrinsicId: string,
   eventId: string
@@ -268,6 +269,7 @@ export function createUnlockedEvent(
     nominatorId: getNominationId(accountId, domainId, operatorId),
     amount,
     storageFee,
+    timestamp,
     blockHeight,
     extrinsicId,
     eventId,

--- a/indexers/staking/src/mappings/eventHandler.ts
+++ b/indexers/staking/src/mappings/eventHandler.ts
@@ -283,6 +283,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     cache,
     height,
     extrinsicEvents,
+    blockTimestamp,
     extrinsicId,
     eventId,
   }) => {
@@ -307,6 +308,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
         accountId,
         amount,
         storageFee,
+        blockTimestamp,
         height,
         extrinsicId,
         eventId


### PR DESCRIPTION
## Fix: Add a row in withdrawals when no row exists on unlock funds (unlockNominators edge case)

When an operator decides to deregister and then unlock nominators, this generates unlock funds events for all nominators, however, we don't have any withdrawals matching these events. So this PR force create these withdrawal rows in this case.