### PR TITLE
Feat: Add support for utility.batchAll on consensus and staking indexer

### DIFF
--- a/indexers/consensus/src/mappings/utils.ts
+++ b/indexers/consensus/src/mappings/utils.ts
@@ -1,4 +1,4 @@
-import { capitalizeFirstLetter } from "@autonomys/auto-utils";
+import { capitalizeFirstLetter, EventRecord } from "@autonomys/auto-utils";
 import { PAD_ZEROS } from "./constants";
 
 export const decodeLog = (value: null | Uint8Array | Uint8Array[]) => {
@@ -33,4 +33,27 @@ export const hexToUint8Array = (hex: string): Uint8Array => {
   return new Uint8Array(
     hex.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || []
   );
+};
+
+export const groupEventsFromBatchAll = (
+  events: EventRecord[]
+): EventRecord[][] => {
+  const result: EventRecord[][] = [];
+  let currentGroup: EventRecord[] = [];
+
+  for (const event of events) {
+    if (
+      event.event.section === "utility" &&
+      event.event.method === "ItemCompleted"
+    ) {
+      if (currentGroup.length > 0) {
+        result.push(currentGroup);
+        currentGroup = [];
+      }
+    } else currentGroup.push(event);
+  }
+
+  if (currentGroup.length > 0) result.push(currentGroup);
+
+  return result;
 };

--- a/indexers/staking/src/mappings/eventHandler.ts
+++ b/indexers/staking/src/mappings/eventHandler.ts
@@ -64,8 +64,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     extrinsicMethodToPrimitive,
   }) => {
     const domainId = event.event.data[0].toString();
-    const extrinsicArgs =
-      extrinsicMethodToPrimitive.args[0].toPrimitive() as any;
+    const extrinsicArgs = extrinsicMethodToPrimitive.args.domain_config_params;
     const domainName = capitalizeFirstLetter(extrinsicArgs.domainName);
     const runtimeId = Number(extrinsicArgs.runtimeId);
 
@@ -96,15 +95,16 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
   }) => {
     const operatorId = event.event.data[0].toString();
     const domainId = event.event.data[1].toString();
-    const totalAmount = BigInt(
-      String(extrinsicMethodToPrimitive.args[1].toPrimitive())
+    const totalAmount = BigInt(String(extrinsicMethodToPrimitive.args.amount));
+    const signingKey = String(
+      extrinsicMethodToPrimitive.args.config.signingKey
     );
-    const operatorDetails =
-      extrinsicMethodToPrimitive.args[2].toPrimitive() as any;
-
-    const signingKey = operatorDetails.signingKey;
-    const minimumNominatorStake = operatorDetails.minimumNominatorStake;
-    const nominationTax = operatorDetails.nominationTax;
+    const minimumNominatorStake = BigInt(
+      extrinsicMethodToPrimitive.args.config.minimumNominatorStake
+    );
+    const nominationTax = Number(
+      extrinsicMethodToPrimitive.args.config.nominationTax
+    );
 
     const storageFeeDepositedEvent = findOneExtrinsicEvent(
       extrinsicEvents,
@@ -205,7 +205,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     const operatorId = event.event.data[0].toString();
     const accountId = event.event.data[1].toString();
     const domainId = findDomainIdFromOperatorsCache(cache, operatorId);
-    const toWithdraw = extrinsicMethodToPrimitive.args[1].toPrimitive() as any;
+    const toWithdraw = stringify(extrinsicMethodToPrimitive.args.to_withdraw);
     const withdrawalInShares = findWithdrawalFromWithdrawalCache(
       cache,
       operatorId,
@@ -222,7 +222,7 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
         accountId,
         domainId,
         operatorId,
-        stringify(toWithdraw),
+        toWithdraw,
         shares,
         storageFeeRefund,
         estimatedAmount,
@@ -368,8 +368,8 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     extrinsicMethodToPrimitive,
   }) => {
     const bundleHash = event.event.data[1].toString();
-    const _extrinsic = extrinsicMethodToPrimitive.args[0].toPrimitive() as any;
-    const { header } = _extrinsic.sealedHeader as SealedBundleHeader;
+    const { header } = extrinsicMethodToPrimitive.args.opaque_bundle
+      .sealedHeader as SealedBundleHeader;
     const domainId = header.proofOfElection.domainId.toString();
     const operatorId = header.proofOfElection.operatorId.toString();
 

--- a/indexers/staking/src/mappings/eventHandler.ts
+++ b/indexers/staking/src/mappings/eventHandler.ts
@@ -18,7 +18,6 @@ import {
 
 type EventHandler = (params: {
   event: EventRecord;
-  extrinsic: any;
   cache: Cache;
   height: bigint;
   blockTimestamp: Date;
@@ -26,6 +25,7 @@ type EventHandler = (params: {
   eventId: string;
   extrinsicSigner: string;
   extrinsicEvents: EventRecord[];
+  extrinsicMethodToPrimitive: any;
 }) => void;
 
 export const EVENT_HANDLERS: Record<string, EventHandler> = {
@@ -36,12 +36,11 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     height,
     extrinsicId,
     eventId,
-    extrinsic,
+    extrinsicMethodToPrimitive,
   }) => {
     const runtimeId = event.event.data[0].toString();
     const runtimeType = event.event.data[1].toString();
-    const extrinsicArgs = extrinsic.method.args[0].toPrimitive() as any;
-    const runtimeName = extrinsicArgs.args.runtime_name;
+    const runtimeName = extrinsicMethodToPrimitive.args.runtime_name;
 
     cache.runtimeCreation.push(
       db.createRuntimeCreation(
@@ -62,10 +61,11 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     height,
     extrinsicId,
     eventId,
-    extrinsic,
+    extrinsicMethodToPrimitive,
   }) => {
     const domainId = event.event.data[0].toString();
-    const extrinsicArgs = extrinsic.method.args[0].toPrimitive() as any;
+    const extrinsicArgs =
+      extrinsicMethodToPrimitive.args[0].toPrimitive() as any;
     const domainName = capitalizeFirstLetter(extrinsicArgs.domainName);
     const runtimeId = Number(extrinsicArgs.runtimeId);
 
@@ -91,13 +91,16 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     blockTimestamp,
     extrinsicId,
     eventId,
-    extrinsic,
     extrinsicEvents,
+    extrinsicMethodToPrimitive,
   }) => {
     const operatorId = event.event.data[0].toString();
     const domainId = event.event.data[1].toString();
-    const totalAmount = BigInt(String(extrinsic.method.args[1].toPrimitive()));
-    const operatorDetails = extrinsic.method.args[2].toPrimitive() as any;
+    const totalAmount = BigInt(
+      String(extrinsicMethodToPrimitive.args[1].toPrimitive())
+    );
+    const operatorDetails =
+      extrinsicMethodToPrimitive.args[2].toPrimitive() as any;
 
     const signingKey = operatorDetails.signingKey;
     const minimumNominatorStake = operatorDetails.minimumNominatorStake;
@@ -197,13 +200,12 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
     blockTimestamp,
     extrinsicId,
     eventId,
-    extrinsic,
-    extrinsicEvents,
+    extrinsicMethodToPrimitive,
   }) => {
     const operatorId = event.event.data[0].toString();
     const accountId = event.event.data[1].toString();
     const domainId = findDomainIdFromOperatorsCache(cache, operatorId);
-    const toWithdraw = extrinsic.method.args[1].toPrimitive() as any;
+    const toWithdraw = extrinsicMethodToPrimitive.args[1].toPrimitive() as any;
     const withdrawalInShares = findWithdrawalFromWithdrawalCache(
       cache,
       operatorId,
@@ -360,13 +362,13 @@ export const EVENT_HANDLERS: Record<string, EventHandler> = {
   "domains.BundleStored": ({
     event,
     cache,
-    extrinsic,
     height,
     extrinsicId,
     eventId,
+    extrinsicMethodToPrimitive,
   }) => {
     const bundleHash = event.event.data[1].toString();
-    const _extrinsic = extrinsic.method.args[0].toPrimitive() as any;
+    const _extrinsic = extrinsicMethodToPrimitive.args[0].toPrimitive() as any;
     const { header } = _extrinsic.sealedHeader as SealedBundleHeader;
     const domainId = header.proofOfElection.domainId.toString();
     const operatorId = header.proofOfElection.operatorId.toString();

--- a/indexers/staking/src/mappings/types.ts
+++ b/indexers/staking/src/mappings/types.ts
@@ -1,3 +1,8 @@
+export type ExtrinsicPrimitive = {
+  callIndex: string;
+  args: any;
+};
+
 export interface TBundle {
   sealedHeader: SealedBundleHeader;
   extrinsics: Uint8Array[];

--- a/indexers/staking/src/mappings/utils.ts
+++ b/indexers/staking/src/mappings/utils.ts
@@ -121,3 +121,26 @@ export const aggregateByDomainId = (
     totalShares: totalSharesSum,
   };
 };
+
+export const groupEventsFromBatchAll = (
+  events: EventRecord[]
+): EventRecord[][] => {
+  const result: EventRecord[][] = [];
+  let currentGroup: EventRecord[] = [];
+
+  for (const event of events) {
+    if (
+      event.event.section === "utility" &&
+      event.event.method === "ItemCompleted"
+    ) {
+      if (currentGroup.length > 0) {
+        result.push(currentGroup);
+        currentGroup = [];
+      }
+    } else currentGroup.push(event);
+  }
+
+  if (currentGroup.length > 0) result.push(currentGroup);
+
+  return result;
+};


### PR DESCRIPTION
## Feat: Add support for utility.batchAll on consensus and staking indexer

This was an issue only for indexers that needed the calldata inside the events handler. If an indexer does not use an events handler (like leaderboard and files), it does not need this feature.
But for consensus and staking, since they do require some of the calldata of the extrinsic to be passdown the event handler (for consensus to know the receiver of an XDM extrinsic, for staking for various extrinsic).

So this PR detects if the extrinsic is a batch, if so, it split the events in groups, according to the child-extrinsic, and extracts the corresponding calldata, then loops these events groups to use the events handler correctly.