### PR TITLE
Fix: match by nominator instead just account

### DIFF
--- a/indexers/db/docker-entrypoint-initdb.d/12-functions-staking.sql
+++ b/indexers/db/docker-entrypoint-initdb.d/12-functions-staking.sql
@@ -1027,7 +1027,7 @@ DECLARE
 BEGIN
     SELECT id INTO withdrawal_id
     FROM staking.withdrawals
-    WHERE status = 'PENDING_UNLOCK_FUNDS' AND account_id = NEW.account_id
+    WHERE status = 'PENDING_UNLOCK_FUNDS' AND nominator_id = NEW.nominator_id
     ORDER BY created_at ASC
     LIMIT 1;
 


### PR DESCRIPTION
## Fix: match by nominator instead just account

only finding the last account withdrawals with the waiting for unlock status open the door to match this to a unlock from a different operator (but same account) while matching with the nominator id is stricter since nominator id is a composite of account, operator id and domain id