### PR TITLE
Feat: Add a db fallback for session

### DIFF
--- a/explorer/src/utils/auth/user.ts
+++ b/explorer/src/utils/auth/user.ts
@@ -1,7 +1,9 @@
+import { NetworkId } from '@autonomys/auto-utils'
 import { UserSession } from '@autonomys/user-session'
 import { SavedUser } from 'next-auth'
+import { queryGraphqlServer } from 'utils/queryGraphqlServer'
 
-const { findUserByID, saveUser } = UserSession<SavedUser>({
+const { findUserByID: findUserByIDAutoEvm, saveUser: saveUserAutoEvm } = UserSession<SavedUser>({
   apiKey: process.env.AUTO_DRIVE_API_KEY || '',
   network: 'mainnet',
   rpcUrl: process.env.AUTO_EVM_RPC_URL || '',
@@ -12,5 +14,75 @@ const { findUserByID, saveUser } = UserSession<SavedUser>({
   showLogs: true,
   waitReceipt: true,
 })
+
+const findUserByID = async (userId: string): Promise<{ cid: string; data: SavedUser } | null> => {
+  try {
+    const NETWORK = process.env.USERS_INDEXER_NETWORK || NetworkId.LOCALHOST
+    const response = await Promise.race([
+      queryGraphqlServer(
+        `
+          query GetSession($userId: String!) {
+            users_session(where: { id: { _eq: $userId}}) {
+              id,
+              data
+            }
+          }`,
+        {
+          userId,
+        },
+        NETWORK,
+      ),
+      findUserByIDAutoEvm(userId),
+    ])
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (response && (response as any).users_session && (response as any).users_session[0])
+      return {
+        cid: 'none',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data: (response as any).users_session[0].data as SavedUser,
+      }
+    if (response) return response as { cid: string; data: SavedUser }
+    return null
+  } catch (error) {
+    console.error('Error finding user:', error)
+    return null
+  }
+}
+
+const saveUser = async (userId: string, user: SavedUser) => {
+  try {
+    const NETWORK = process.env.USERS_INDEXER_NETWORK || NetworkId.LOCALHOST
+    const response = await Promise.race([
+      queryGraphqlServer(
+        `
+          mutation SaveSession($user: users_session_insert_input!) {
+            insert_users_session_one(object: $user) {
+              id,
+              data
+            }
+          }`,
+        {
+          user: {
+            id: userId,
+            dids: user.DIDs,
+            data: user,
+          },
+        },
+        NETWORK,
+      ),
+      saveUserAutoEvm(userId, user),
+    ])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((response as any).insert_users_session_one)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (response as any).insert_users_session_one.data
+    if (response) return response
+    return null
+  } catch (error) {
+    console.error('Error saving user:', error)
+    return null
+  }
+}
 
 export { findUserByID, saveUser }

--- a/indexers/db/docker-entrypoint-initdb.d/02-schema-users.sql
+++ b/indexers/db/docker-entrypoint-initdb.d/02-schema-users.sql
@@ -129,3 +129,15 @@ CREATE TABLE users.tags (
 );
 ALTER TABLE users.tags OWNER TO postgres;
 ALTER TABLE ONLY users.tags ADD CONSTRAINT tags_pkey PRIMARY KEY (id);
+
+CREATE TABLE users.session (
+    id TEXT NOT NULL,
+    dids TEXT[] NOT NULL,
+    data jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (id)
+);
+ALTER TABLE users.session OWNER TO postgres;
+ALTER TABLE ONLY users.session ADD CONSTRAINT session_pkey PRIMARY KEY (id);

--- a/indexers/db/metadata/databases/default/tables/tables.yaml
+++ b/indexers/db/metadata/databases/default/tables/tables.yaml
@@ -125,5 +125,6 @@
 - "!include users_api_keys_monthly_usage.yaml"
 - "!include users_api_monthly_usage.yaml"
 - "!include users_profiles.yaml"
+- "!include users_session.yaml"
 - "!include users_tags.yaml"
 - "!include users_wallets.yaml"

--- a/indexers/db/metadata/databases/default/tables/users_session.yaml
+++ b/indexers/db/metadata/databases/default/tables/users_session.yaml
@@ -1,0 +1,3 @@
+table:
+  name: session
+  schema: users


### PR DESCRIPTION
## Feat: Add a db fallback for session

The current user session flow work, but it's pretty slow, especially for new session, as it need to first read from Auto EVM to see if the session exist, if not, write the Auto Drive file then write to Auto EVM to store the file cid with the user id hash.

This is also prone to bottleneck and error, especially if multiple transactions are sent simultaneously, (no nonce management or multiple wallets to use).

To not be detrimental to UX while still using this solution, I added a db flow, that will write and read to our db the sessions. this flow work as a Promise.race so either the onchain User Session or the db flow resolve the first, will be the one use.