### PR TITLE
Fix: Improve mobile header

### DIFF
--- a/explorer/src/components/Profile/ProfileButton.tsx
+++ b/explorer/src/components/Profile/ProfileButton.tsx
@@ -30,7 +30,7 @@ export const ProfileButton: FC = () => {
       onClick={() => push(INTERNAL_ROUTES.profile.page(network))}
       className={cn(
         'inline-flex items-center bg-white p-0 text-base shadow-md hover:bg-gray-200 focus:outline-none dark:bg-buttonLightTo',
-        isDesktop ? 'ml-4 rounded-full' : '',
+        isDesktop ? 'ml-4 rounded-full' : 'ml-2',
       )}
     >
       {profile?.avatar ? (

--- a/explorer/src/components/Profile/ProfileButton.tsx
+++ b/explorer/src/components/Profile/ProfileButton.tsx
@@ -29,8 +29,8 @@ export const ProfileButton: FC = () => {
     <button
       onClick={() => push(INTERNAL_ROUTES.profile.page(network))}
       className={cn(
-        'inline-flex items-center bg-white p-0 text-base shadow-md hover:bg-gray-200 focus:outline-none dark:bg-buttonLightTo md:mt-3',
-        isDesktop ? 'ml-4 rounded-full' : 'rounded-r-full',
+        'inline-flex items-center bg-white p-0 text-base shadow-md hover:bg-gray-200 focus:outline-none dark:bg-buttonLightTo',
+        isDesktop ? 'ml-4 rounded-full' : '',
       )}
     >
       {profile?.avatar ? (

--- a/explorer/src/components/WalletButton/AccountListDropdown.tsx
+++ b/explorer/src/components/WalletButton/AccountListDropdown.tsx
@@ -99,8 +99,8 @@ function AccountListDropdown({ className, labelClassName }: AccountListDropdownP
             `relative w-full cursor-default font-["Montserrat"] ${
               isDesktop
                 ? 'rounded-full pr-10 dark:bg-buttonLightTo'
-                : 'rounded-l-full pr-6 dark:bg-primaryAccent'
-            } bg-white py-2 pl-3 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 dark:text-white sm:text-sm md:mt-3`,
+                : 'rounded-l-full pr-0 dark:bg-primaryAccent'
+            } ml-2 bg-white py-3 pl-3 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 dark:text-white sm:text-sm md:mt-3`,
             className,
           )}
         >
@@ -111,14 +111,16 @@ function AccountListDropdown({ className, labelClassName }: AccountListDropdownP
             >
               {accountAddress}
             </span>
-            <span className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2'>
-              <ChevronDownIcon
-                className={`size-5 text-gray-400 ui-open:rotate-180${
-                  isDesktop ? 'dark:text-primaryAccent' : 'dark:text-white'
-                }`}
-                aria-hidden='true'
-              />
-            </span>
+            {isDesktop && (
+              <span className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2'>
+                <ChevronDownIcon
+                  className={`size-5 text-gray-400 ui-open:rotate-180${
+                    isDesktop ? 'dark:text-primaryAccent' : 'dark:text-white'
+                  }`}
+                  aria-hidden='true'
+                />
+              </span>
+            )}
           </div>
         </Listbox.Button>
         <Transition

--- a/explorer/src/components/WalletSideKick/index.tsx
+++ b/explorer/src/components/WalletSideKick/index.tsx
@@ -5,20 +5,14 @@
 import { sendGAEvent } from '@next/third-parties/google'
 import { LogoIcon } from 'components/icons/LogoIcon'
 import { HeaderBackground } from 'components/layout/HeaderBackground'
-import {
-  ROUTE_EXTRA_FLAGS,
-  ROUTE_EXTRA_FLAG_TYPE,
-  ROUTE_FLAG_VALUE_OPEN_CLOSE,
-} from 'constants/routes'
+import { ROUTE_EXTRA_FLAGS, ROUTE_EXTRA_FLAG_TYPE } from 'constants/routes'
 import { WalletType } from 'constants/wallet'
 import useIndexers from 'hooks/useIndexers'
 import useMediaQuery from 'hooks/useMediaQuery'
 import useWallet from 'hooks/useWallet'
 import Image from 'next/image'
-import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useTransactionsStates } from 'states/transactions'
+import { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { formatUnitsToNumber } from 'utils/number'
 import { currentYear } from 'utils/time'
 import { AccountHeader } from './AccountHeader'
@@ -32,35 +26,6 @@ import { StakingSummary } from './StakingSummary'
 type DrawerProps = {
   isOpen: boolean
   onCloseSidebar: () => void
-}
-
-const PendingTransactionsLabel: FC = () => {
-  const { pendingTransactions } = useTransactionsStates()
-  const isDesktop = useMediaQuery('(min-width: 1024px)')
-  const count = useMemo(
-    () => (pendingTransactions ? pendingTransactions.length : 0),
-    [pendingTransactions],
-  )
-
-  useEffect(() => {
-    sendGAEvent('event', 'walletSideKick_pending_transactions', { value: count })
-  }, [count])
-
-  if (count === 0) return null
-
-  return (
-    <div
-      className={
-        !isDesktop
-          ? 'inline-flex items-center bg-primaryAccent p-2 pl-1 pr-1 text-xs shadow-md hover:bg-gray-200 focus:outline-none dark:text-white'
-          : 'ml-4 rounded-full from-primaryAccent to-blueUndertone p-2 pl-4 pr-4 shadow-md dark:bg-boxDark dark:text-white'
-      }
-    >
-      <Link href={`?${ROUTE_EXTRA_FLAG_TYPE.WALLET_SIDEKICK}=${ROUTE_FLAG_VALUE_OPEN_CLOSE.OPEN}`}>
-        {count}
-      </Link>
-    </div>
-  )
 }
 
 export const WalletSidekick: FC = () => {
@@ -113,7 +78,6 @@ export const WalletSidekick: FC = () => {
 
   return (
     <>
-      <PendingTransactionsLabel />
       <button
         onClick={onClick}
         className={`inline-flex items-center bg-white p-2 text-base hover:bg-gray-200 focus:outline-none ${

--- a/explorer/src/components/WalletSideKick/index.tsx
+++ b/explorer/src/components/WalletSideKick/index.tsx
@@ -80,8 +80,8 @@ export const WalletSidekick: FC = () => {
     <>
       <button
         onClick={onClick}
-        className={`inline-flex items-center bg-white p-2 text-base hover:bg-gray-200 focus:outline-none ${
-          isDesktop ? 'ml-4 rounded-full' : 'rounded-r-full'
+        className={`inline-flex items-center bg-white text-base hover:bg-gray-200 focus:outline-none ${
+          isDesktop ? 'ml-4 rounded-full p-2' : 'rounded-r-full'
         } shadow-md dark:bg-buttonLightTo md:mt-3`}
       >
         <Image

--- a/explorer/src/components/layout/ConsensusHeader.tsx
+++ b/explorer/src/components/layout/ConsensusHeader.tsx
@@ -23,7 +23,7 @@ export const ConsensusHeader: FC = () => {
   const menuList = useMemo(() => getSupportedHeaderLinks(network, Routes.consensus), [network])
 
   return (
-    <header className='body-font z-9 text-gray-600'>
+    <header className={`body-font z-9 text-gray-600 ${isDesktop ? 'py-5' : 'py-2'}`}>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/ConsensusHeader.tsx
+++ b/explorer/src/components/layout/ConsensusHeader.tsx
@@ -23,7 +23,7 @@ export const ConsensusHeader: FC = () => {
   const menuList = useMemo(() => getSupportedHeaderLinks(network, Routes.consensus), [network])
 
   return (
-    <header className='body-font z-9 py-[30px] text-gray-600'>
+    <header className='body-font z-9 text-gray-600'>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/DomainHeader.tsx
+++ b/explorer/src/components/layout/DomainHeader.tsx
@@ -32,7 +32,7 @@ export const DomainHeader = () => {
   )
 
   return (
-    <header className='body-font z-9 py-[30px] text-gray-600'>
+    <header className='body-font z-9 text-gray-600'>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/DomainHeader.tsx
+++ b/explorer/src/components/layout/DomainHeader.tsx
@@ -32,7 +32,7 @@ export const DomainHeader = () => {
   )
 
   return (
-    <header className='body-font z-9 text-gray-600'>
+    <header className={`body-font z-9 text-gray-600 ${isDesktop ? 'py-5' : 'py-2'}`}>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/EmptyHeader.tsx
+++ b/explorer/src/components/layout/EmptyHeader.tsx
@@ -18,7 +18,7 @@ export const EmptyHeader = () => {
   const { network } = useIndexers()
 
   return (
-    <header className='body-font z-9 text-gray-600'>
+    <header className={`body-font z-9 text-gray-600 ${isDesktop ? 'py-5' : 'py-2'}`}>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/EmptyHeader.tsx
+++ b/explorer/src/components/layout/EmptyHeader.tsx
@@ -18,7 +18,7 @@ export const EmptyHeader = () => {
   const { network } = useIndexers()
 
   return (
-    <header className='body-font z-9 py-[30px] text-gray-600'>
+    <header className='body-font z-9 text-gray-600'>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/FarmingHeader.tsx
+++ b/explorer/src/components/layout/FarmingHeader.tsx
@@ -38,7 +38,7 @@ export const FarmingHeader = () => {
   )
 
   return (
-    <header className='body-font z-9 py-[30px] text-gray-600'>
+    <header className='body-font z-9 text-gray-600'>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/FarmingHeader.tsx
+++ b/explorer/src/components/layout/FarmingHeader.tsx
@@ -38,7 +38,7 @@ export const FarmingHeader = () => {
   )
 
   return (
-    <header className='body-font z-9 text-gray-600'>
+    <header className={`body-font z-9 text-gray-600 ${isDesktop ? 'py-5' : 'py-2'}`}>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/LeaderboardHeader.tsx
+++ b/explorer/src/components/layout/LeaderboardHeader.tsx
@@ -23,7 +23,7 @@ export const LeaderboardHeader: FC = () => {
   const menuList = useMemo(() => getSupportedHeaderLinks(network, Routes.leaderboard), [network])
 
   return (
-    <header className='body-font z-9 py-[30px] text-gray-600'>
+    <header className='body-font z-9 text-gray-600'>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/LeaderboardHeader.tsx
+++ b/explorer/src/components/layout/LeaderboardHeader.tsx
@@ -23,7 +23,7 @@ export const LeaderboardHeader: FC = () => {
   const menuList = useMemo(() => getSupportedHeaderLinks(network, Routes.leaderboard), [network])
 
   return (
-    <header className='body-font z-9 text-gray-600'>
+    <header className={`body-font z-9 text-gray-600 ${isDesktop ? 'py-5' : 'py-2'}`}>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/ProfileHeader.tsx
+++ b/explorer/src/components/layout/ProfileHeader.tsx
@@ -37,7 +37,7 @@ export const ProfileHeader = () => {
   }, [profile])
 
   return (
-    <header className='body-font z-9 py-[30px] text-gray-600'>
+    <header className='body-font z-9 text-gray-600'>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/ProfileHeader.tsx
+++ b/explorer/src/components/layout/ProfileHeader.tsx
@@ -37,7 +37,7 @@ export const ProfileHeader = () => {
   }, [profile])
 
   return (
-    <header className='body-font z-9 text-gray-600'>
+    <header className={`body-font z-9 text-gray-600 ${isDesktop ? 'py-5' : 'py-2'}`}>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/SectionHeader.tsx
+++ b/explorer/src/components/layout/SectionHeader.tsx
@@ -68,7 +68,7 @@ export const SectionHeader: FC = () => {
               <button
                 className={
                   isActive
-                    ? 'rounded-full bg-buttonLightFrom px-2 py-2 text-white dark:bg-primaryAccent'
+                    ? `rounded-full bg-buttonLightFrom ${isDesktop ? 'px-4' : 'px-2'} py-2 text-white dark:bg-primaryAccent`
                     : 'text-grayDark dark:text-white'
                 }
               >
@@ -88,7 +88,7 @@ export const SectionHeader: FC = () => {
       data-accordion='open'
     >
       <div className='container mx-auto flex w-full items-center justify-between px-5 pb-2 pt-0 md:px-[25px] 2xl:px-0'>
-        <div className='flex gap-2 pt-3'>{domainsOptions}</div>
+        <div className={`flex pt-3 ${isDesktop ? 'gap-9' : 'gap-2'}`}>{domainsOptions}</div>
         <div className='flex gap-4'>
           {!actingAccount ? (
             <WalletButton />

--- a/explorer/src/components/layout/SectionHeader.tsx
+++ b/explorer/src/components/layout/SectionHeader.tsx
@@ -68,7 +68,7 @@ export const SectionHeader: FC = () => {
               <button
                 className={
                   isActive
-                    ? 'rounded-full bg-buttonLightFrom px-4 py-2 text-white dark:bg-primaryAccent'
+                    ? 'rounded-full bg-buttonLightFrom px-2 py-2 text-white dark:bg-primaryAccent'
                     : 'text-grayDark dark:text-white'
                 }
               >
@@ -88,12 +88,12 @@ export const SectionHeader: FC = () => {
       data-accordion='open'
     >
       <div className='container mx-auto flex w-full items-center justify-between px-5 pb-2 pt-0 md:px-[25px] 2xl:px-0'>
-        <div className='flex gap-9 pt-3'>{domainsOptions}</div>
+        <div className='flex gap-2 pt-3'>{domainsOptions}</div>
         <div className='flex gap-4'>
           {!actingAccount ? (
             <WalletButton />
           ) : (
-            <div className='flex'>
+            <div className={`flex ${isDesktop ? '' : 'mb-2'}`}>
               <AccountListDropdown />
               {sessionSubspaceAccount && <ProfileButton />}
               <WalletSidekick />

--- a/explorer/src/components/layout/StakingHeader.tsx
+++ b/explorer/src/components/layout/StakingHeader.tsx
@@ -23,7 +23,7 @@ export const StakingHeader = () => {
   const menuList = useMemo(() => getSupportedHeaderLinks(network, Routes.staking), [network])
 
   return (
-    <header className='body-font z-9 text-gray-600'>
+    <header className={`body-font z-9 text-gray-600 ${isDesktop ? 'py-5' : 'py-2'}`}>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/StakingHeader.tsx
+++ b/explorer/src/components/layout/StakingHeader.tsx
@@ -23,7 +23,7 @@ export const StakingHeader = () => {
   const menuList = useMemo(() => getSupportedHeaderLinks(network, Routes.staking), [network])
 
   return (
-    <header className='body-font z-9 py-[30px] text-gray-600'>
+    <header className='body-font z-9 text-gray-600'>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/StorageHeader.tsx
+++ b/explorer/src/components/layout/StorageHeader.tsx
@@ -29,7 +29,7 @@ export const StorageHeader: FC = () => {
   }, [pathname])
 
   return (
-    <header className='body-font z-9 text-gray-600'>
+    <header className={`body-font z-9 text-gray-600 ${isDesktop ? 'py-5' : 'py-2'}`}>
       {isDesktop ? (
         <div>
           <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-2 md:flex-row md:px-[25px] 2xl:px-0'>

--- a/explorer/src/components/layout/StorageHeader.tsx
+++ b/explorer/src/components/layout/StorageHeader.tsx
@@ -24,12 +24,12 @@ export const StorageHeader: FC = () => {
   const menuList = useMemo(() => getSupportedHeaderLinks(network, Routes.storage), [network])
 
   const showBanner = useMemo(() => {
-    const regex = /^\/(taurus|mainnet)\/permanent-storage(\/(files|folders)?)?$/;
-    return regex.test(pathname);
-  }, [pathname]);
+    const regex = /^\/(taurus|mainnet)\/permanent-storage(\/(files|folders)?)?$/
+    return regex.test(pathname)
+  }, [pathname])
 
   return (
-    <header className='body-font z-9 py-[30px] text-gray-600'>
+    <header className='body-font z-9 text-gray-600'>
       {isDesktop ? (
         <div>
           <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-2 md:flex-row md:px-[25px] 2xl:px-0'>
@@ -67,8 +67,8 @@ export const StorageHeader: FC = () => {
               </button>
             </div>
           </div>
-          { showBanner && <StorageBanner/>}
-          <nav className='flex flex-wrap items-center justify-center gap-10 text-sm py-5'>
+          {showBanner && <StorageBanner />}
+          <nav className='flex flex-wrap items-center justify-center gap-10 py-5 text-sm'>
             {menuList.map((item, index) => {
               const isCurrentPath = pathname.includes(item.link)
               return (
@@ -89,25 +89,29 @@ export const StorageHeader: FC = () => {
         </div>
       ) : (
         <>
-        <div className='flex flex-row items-center justify-between px-5 py-2'>
-          <Link
-            href={`/${network}/${section}`}
-            className='title-font flex items-center font-medium text-gray-900 dark:text-white'
-          >
-            <LogoIcon fillColor='currentColor' />
-          </Link>
-          <div className='flex items-center gap-4'>
-            <HeaderChainDropdown />
-            <button
-              className='items-center rounded-full bg-buttonLightFrom p-3 text-white dark:bg-white dark:text-blueAccent'
-              onClick={() => setIsOpen(true)}
+          <div className='flex flex-row items-center justify-between px-5 py-2'>
+            <Link
+              href={`/${network}/${section}`}
+              className='title-font flex items-center font-medium text-gray-900 dark:text-white'
             >
-              <Bars3BottomRightIcon className='size-4' fill='currentColor' stroke='currentColor' />
-            </button>
+              <LogoIcon fillColor='currentColor' />
+            </Link>
+            <div className='flex items-center gap-4'>
+              <HeaderChainDropdown />
+              <button
+                className='items-center rounded-full bg-buttonLightFrom p-3 text-white dark:bg-white dark:text-blueAccent'
+                onClick={() => setIsOpen(true)}
+              >
+                <Bars3BottomRightIcon
+                  className='size-4'
+                  fill='currentColor'
+                  stroke='currentColor'
+                />
+              </button>
+            </div>
+            <MobileHeader menuList={menuList} isOpen={isOpen} setIsOpen={setIsOpen} />
           </div>
-          <MobileHeader menuList={menuList} isOpen={isOpen} setIsOpen={setIsOpen} />
-        </div>
-        {showBanner && <StorageBanner/>}
+          {showBanner && <StorageBanner />}
         </>
       )}
     </header>

--- a/explorer/src/components/layout/TransferHeader.tsx
+++ b/explorer/src/components/layout/TransferHeader.tsx
@@ -23,7 +23,7 @@ export const TransferHeader = () => {
   const menuList = useMemo(() => getSupportedHeaderLinks(network, Routes.transfer), [network])
 
   return (
-    <header className='body-font z-9 text-gray-600'>
+    <header className={`body-font z-9 text-gray-600 ${isDesktop ? 'py-5' : 'py-2'}`}>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/TransferHeader.tsx
+++ b/explorer/src/components/layout/TransferHeader.tsx
@@ -23,7 +23,7 @@ export const TransferHeader = () => {
   const menuList = useMemo(() => getSupportedHeaderLinks(network, Routes.transfer), [network])
 
   return (
-    <header className='body-font z-9 py-[30px] text-gray-600'>
+    <header className='body-font z-9 text-gray-600'>
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link


### PR DESCRIPTION
## Fix: Improve mobile header

### Before 

![image](https://github.com/user-attachments/assets/9d3a9e61-eaee-4195-b18a-93da833e0de8)
![image](https://github.com/user-attachments/assets/e7df05f5-517c-4305-ba80-af1528fcf783)


### After

![image](https://github.com/user-attachments/assets/d9bfe427-cc8a-4c35-aa4e-31ddfc7b2b4c)

It could be improved further, the menu start to be cluther by too many section and the icons on mobile are not all very easy to understand what they link to