### PR TITLE
Fix: Change max downloader bach size to 50

### DIFF
--- a/explorer/src/constants/general.ts
+++ b/explorer/src/constants/general.ts
@@ -3,7 +3,7 @@ export const PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50]
 
 export const STAKE_WARS_PAGE_SIZE = 150
 
-export const MAX_DOWNLOADER_BATCH_SIZE = 100
+export const MAX_DOWNLOADER_BATCH_SIZE = 50
 
 export const STAKE_WARS_PHASES = {
   phase2: {


### PR DESCRIPTION
## Fix: Change max downloader bach size to 50

Since we have a permission limit of 50 row per query, if trying to download a query that has more than 50 row it will create an issue since it's creating batch of 100