### PR TITLE
Fix: Wallet sidekick staking summary

### DIFF
--- a/explorer/gql/graphql.tsx
+++ b/explorer/gql/graphql.tsx
@@ -27686,7 +27686,7 @@ export type StakingSummaryQueryVariables = Exact<{
 }>;
 
 
-export type StakingSummaryQuery = { __typename?: 'query_root', staking_operators: Array<{ __typename?: 'staking_operators', id: string, account_id: string, domain_id: string, current_total_stake: any, current_total_shares: any }>, staking_operators_aggregate: { __typename?: 'staking_operators_aggregate', aggregate?: { __typename?: 'staking_operators_aggregate_fields', count: number } | null }, staking_nominators: Array<{ __typename?: 'staking_nominators', id: string, known_shares: any, known_storage_fee_deposit: any, account?: { __typename?: 'staking_accounts', id: string } | null, operator?: { __typename?: 'staking_operators', id: string, account_id: string, domain_id: string, current_total_stake: any, current_total_shares: any, current_share_price: any } | null, deposits: Array<{ __typename?: 'staking_deposits', id: string, amount: any, storage_fee_deposit: any, total_amount: any, estimated_shares: any, timestamp: any, extrinsic_id: string, status: string, created_at: any, updated_at: any }>, withdrawals: Array<{ __typename?: 'staking_withdrawals', id: string, shares: any, storage_fee_refund: any, estimated_amount: any, unlocked_amount: any, unlocked_storage_fee: any, total_amount: any, timestamp: any, withdraw_extrinsic_id: string, unlock_extrinsic_id: string, status: string, created_at: any, domain_block_number_ready_at: any, unlocked_at: any, updated_at: any }>, unlocked_events: Array<{ __typename?: 'staking_unlocked_events', id: string, amount: any, storage_fee: any, block_height: any, extrinsic_id: string }> }>, staking_nominators_aggregate: { __typename?: 'staking_nominators_aggregate', aggregate?: { __typename?: 'staking_nominators_aggregate_fields', count: number } | null } };
+export type StakingSummaryQuery = { __typename?: 'query_root', staking_operators: Array<{ __typename?: 'staking_operators', id: string, account_id: string, domain_id: string, current_total_stake: any, current_total_shares: any }>, staking_operators_aggregate: { __typename?: 'staking_operators_aggregate', aggregate?: { __typename?: 'staking_operators_aggregate_fields', count: number } | null }, staking_nominators: Array<{ __typename?: 'staking_nominators', id: string, known_shares: any, known_storage_fee_deposit: any, account?: { __typename?: 'staking_accounts', id: string } | null, operator?: { __typename?: 'staking_operators', id: string, account_id: string, domain_id: string, current_total_stake: any, current_total_shares: any, current_share_price: any } | null, deposits: Array<{ __typename?: 'staking_deposits', estimated_shares: any }>, withdrawals: Array<{ __typename?: 'staking_withdrawals', unlocked_amount: any, unlocked_storage_fee: any, total_amount: any }> }>, staking_nominators_aggregate: { __typename?: 'staking_nominators_aggregate', aggregate?: { __typename?: 'staking_nominators_aggregate_fields', count: number } | null } };
 
 export type LastBlockQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -32044,40 +32044,12 @@ export const StakingSummaryDocument = gql`
       current_share_price
     }
     deposits {
-      id
-      amount
-      storage_fee_deposit
-      total_amount
       estimated_shares
-      timestamp
-      extrinsic_id
-      status
-      created_at
-      updated_at
     }
     withdrawals {
-      id
-      shares
-      storage_fee_refund
-      estimated_amount
       unlocked_amount
       unlocked_storage_fee
       total_amount
-      timestamp
-      withdraw_extrinsic_id
-      unlock_extrinsic_id
-      status
-      created_at
-      domain_block_number_ready_at
-      unlocked_at
-      updated_at
-    }
-    unlocked_events {
-      id
-      amount
-      storage_fee
-      block_height
-      extrinsic_id
     }
   }
   staking_nominators_aggregate(

--- a/explorer/gql/graphql.tsx
+++ b/explorer/gql/graphql.tsx
@@ -27686,7 +27686,7 @@ export type StakingSummaryQueryVariables = Exact<{
 }>;
 
 
-export type StakingSummaryQuery = { __typename?: 'query_root', staking_operators: Array<{ __typename?: 'staking_operators', id: string, account_id: string, domain_id: string, current_total_stake: any, current_total_shares: any }>, staking_operators_aggregate: { __typename?: 'staking_operators_aggregate', aggregate?: { __typename?: 'staking_operators_aggregate_fields', count: number } | null }, staking_nominators: Array<{ __typename?: 'staking_nominators', id: string, known_shares: any, known_storage_fee_deposit: any, account?: { __typename?: 'staking_accounts', id: string } | null, operator?: { __typename?: 'staking_operators', id: string, account_id: string, domain_id: string, current_total_stake: any, current_total_shares: any } | null }>, staking_nominators_aggregate: { __typename?: 'staking_nominators_aggregate', aggregate?: { __typename?: 'staking_nominators_aggregate_fields', count: number } | null } };
+export type StakingSummaryQuery = { __typename?: 'query_root', staking_operators: Array<{ __typename?: 'staking_operators', id: string, account_id: string, domain_id: string, current_total_stake: any, current_total_shares: any }>, staking_operators_aggregate: { __typename?: 'staking_operators_aggregate', aggregate?: { __typename?: 'staking_operators_aggregate_fields', count: number } | null }, staking_nominators: Array<{ __typename?: 'staking_nominators', id: string, known_shares: any, known_storage_fee_deposit: any, account?: { __typename?: 'staking_accounts', id: string } | null, operator?: { __typename?: 'staking_operators', id: string, account_id: string, domain_id: string, current_total_stake: any, current_total_shares: any, current_share_price: any } | null, deposits: Array<{ __typename?: 'staking_deposits', id: string, amount: any, storage_fee_deposit: any, total_amount: any, estimated_shares: any, timestamp: any, extrinsic_id: string, status: string, created_at: any, updated_at: any }>, withdrawals: Array<{ __typename?: 'staking_withdrawals', id: string, shares: any, storage_fee_refund: any, estimated_amount: any, unlocked_amount: any, unlocked_storage_fee: any, total_amount: any, timestamp: any, withdraw_extrinsic_id: string, unlock_extrinsic_id: string, status: string, created_at: any, domain_block_number_ready_at: any, unlocked_at: any, updated_at: any }>, unlocked_events: Array<{ __typename?: 'staking_unlocked_events', id: string, amount: any, storage_fee: any, block_height: any, extrinsic_id: string }> }>, staking_nominators_aggregate: { __typename?: 'staking_nominators_aggregate', aggregate?: { __typename?: 'staking_nominators_aggregate_fields', count: number } | null } };
 
 export type LastBlockQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -32041,6 +32041,43 @@ export const StakingSummaryDocument = gql`
       domain_id
       current_total_stake
       current_total_shares
+      current_share_price
+    }
+    deposits {
+      id
+      amount
+      storage_fee_deposit
+      total_amount
+      estimated_shares
+      timestamp
+      extrinsic_id
+      status
+      created_at
+      updated_at
+    }
+    withdrawals {
+      id
+      shares
+      storage_fee_refund
+      estimated_amount
+      unlocked_amount
+      unlocked_storage_fee
+      total_amount
+      timestamp
+      withdraw_extrinsic_id
+      unlock_extrinsic_id
+      status
+      created_at
+      domain_block_number_ready_at
+      unlocked_at
+      updated_at
+    }
+    unlocked_events {
+      id
+      amount
+      storage_fee
+      block_height
+      extrinsic_id
     }
   }
   staking_nominators_aggregate(

--- a/explorer/src/components/WalletSideKick/StakingSummary.tsx
+++ b/explorer/src/components/WalletSideKick/StakingSummary.tsx
@@ -70,10 +70,11 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
             .filter((n) => n.operator?.account_id === subspaceAccount)
             .reduce((acc, nominator) => {
               const totalShares = nominator.deposits.reduce(
-                (acc, curr) => acc + BigInt(curr.estimated_shares),
+                (acc, curr) => acc + BigInt(curr.estimated_shares || 0),
                 BIGINT_ZERO,
               )
-              const estimatedStake = BigInt(nominator.operator?.current_share_price) * totalShares
+              const estimatedStake =
+                BigInt(nominator.operator?.current_share_price || 0) * totalShares
               return estimatedStake > BIGINT_ZERO
                 ? acc + estimatedStake / SHARES_CALCULATION_MULTIPLIER
                 : acc
@@ -97,10 +98,11 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
             .filter((n) => n.operator?.account_id !== subspaceAccount)
             .reduce((acc, nominator) => {
               const totalShares = nominator.deposits.reduce(
-                (acc, curr) => acc + BigInt(curr.estimated_shares),
+                (acc, curr) => acc + BigInt(curr.estimated_shares || 0),
                 BIGINT_ZERO,
               )
-              const estimatedStake = BigInt(nominator.operator?.current_share_price) * totalShares
+              const estimatedStake =
+                BigInt(nominator.operator?.current_share_price || 0) * totalShares
               return estimatedStake > BIGINT_ZERO
                 ? acc + estimatedStake / SHARES_CALCULATION_MULTIPLIER
                 : acc

--- a/explorer/src/components/WalletSideKick/StakingSummary.tsx
+++ b/explorer/src/components/WalletSideKick/StakingSummary.tsx
@@ -2,7 +2,12 @@ import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { Accordion } from 'components/common/Accordion'
 import { List, StyledListItem } from 'components/common/List'
 import { BIGINT_ZERO, SHARES_CALCULATION_MULTIPLIER } from 'constants/general'
-import { ROUTE_EXTRA_FLAG_TYPE, ROUTE_FLAG_VALUE_OPEN_CLOSE, Routes } from 'constants/routes'
+import {
+  ROUTE_EXTRA_FLAG_TYPE,
+  ROUTE_FLAG_VALUE_OPEN_CLOSE,
+  Routes,
+  RoutesStaking,
+} from 'constants/routes'
 import {
   StakingSummaryDocument,
   StakingSummaryQuery,
@@ -145,7 +150,7 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
                   key={'totalOperatorStake'}
                   data-testid='totalOperatorStake-link'
                   className='hover:text-primaryAccent'
-                  href={`/${network}/${Routes.staking}`}
+                  href={`/${network}/${Routes.staking}/${RoutesStaking.nominations}`}
                 >
                   <StyledListItem title='Your total staked in your own operators'>
                     {bigNumberToNumber(totalOperatorStake)} {tokenSymbol}
@@ -157,7 +162,7 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
                   key={'totalNominatedStake'}
                   data-testid='totalNominatedStake-link'
                   className='hover:text-primaryAccent'
-                  href={`/${network}/${Routes.staking}`}
+                  href={`/${network}/${Routes.staking}/${RoutesStaking.nominations}`}
                 >
                   <StyledListItem title='Your total nominated to other operators'>
                     {bigNumberToNumber(totalNominatedStake)} {tokenSymbol}
@@ -169,7 +174,7 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
                   key={'totalOperatorCount'}
                   data-testid='totalOperatorCount-link'
                   className='hover:text-primaryAccent'
-                  href={`/${network}/${Routes.staking}`}
+                  href={`/${network}/${Routes.staking}/${RoutesStaking.nominations}`}
                 >
                   <StyledListItem title='Amount of operators you control'>
                     {totalOperatorCount}
@@ -181,9 +186,9 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
                   key={'totalNominatedCount'}
                   data-testid='totalNominatedCount-link'
                   className='hover:text-primaryAccent'
-                  href={`/${network}/${Routes.staking}`}
+                  href={`/${network}/${Routes.staking}/${RoutesStaking.nominations}`}
                 >
-                  <StyledListItem title='Amount of nomination'>
+                  <StyledListItem title='Amount of nominations'>
                     {totalNominatedCount}
                   </StyledListItem>
                 </Link>

--- a/explorer/src/components/WalletSideKick/StakingSummary.tsx
+++ b/explorer/src/components/WalletSideKick/StakingSummary.tsx
@@ -1,7 +1,7 @@
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { Accordion } from 'components/common/Accordion'
 import { List, StyledListItem } from 'components/common/List'
-import { BIGINT_ZERO } from 'constants/general'
+import { BIGINT_ZERO, SHARES_CALCULATION_MULTIPLIER } from 'constants/general'
 import { ROUTE_EXTRA_FLAG_TYPE, ROUTE_FLAG_VALUE_OPEN_CLOSE, Routes } from 'constants/routes'
 import {
   StakingSummaryDocument,
@@ -63,17 +63,16 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
       hasValue(stakingSummary)
         ? stakingSummary.value.staking_nominators
             .filter((n) => n.operator?.account_id === subspaceAccount)
-            .reduce(
-              (acc, nominator) =>
-                BigInt(nominator.known_shares) > BIGINT_ZERO
-                  ? acc +
-                    BigInt(nominator.known_storage_fee_deposit) +
-                    (BigInt(nominator.operator?.current_total_stake) /
-                      BigInt(nominator.operator?.current_total_shares)) *
-                      BigInt(nominator.known_shares)
-                  : acc,
-              BIGINT_ZERO,
-            )
+            .reduce((acc, nominator) => {
+              const totalShares = nominator.deposits.reduce(
+                (acc, curr) => acc + BigInt(curr.estimated_shares),
+                BIGINT_ZERO,
+              )
+              const estimatedStake = BigInt(nominator.operator?.current_share_price) * totalShares
+              return estimatedStake > BIGINT_ZERO
+                ? acc + estimatedStake / SHARES_CALCULATION_MULTIPLIER
+                : acc
+            }, BIGINT_ZERO)
         : BIGINT_ZERO,
     [stakingSummary, subspaceAccount],
   )
@@ -91,17 +90,16 @@ export const StakingSummary: FC<StakingSummaryProps> = ({ subspaceAccount, token
       hasValue(stakingSummary)
         ? stakingSummary.value.staking_nominators
             .filter((n) => n.operator?.account_id !== subspaceAccount)
-            .reduce(
-              (acc, nominator) =>
-                BigInt(nominator.known_shares) > BIGINT_ZERO
-                  ? acc +
-                    BigInt(nominator.known_storage_fee_deposit) +
-                    (BigInt(nominator.operator?.current_total_stake) /
-                      BigInt(nominator.operator?.current_total_shares)) *
-                      BigInt(nominator.known_shares)
-                  : acc,
-              BIGINT_ZERO,
-            )
+            .reduce((acc, nominator) => {
+              const totalShares = nominator.deposits.reduce(
+                (acc, curr) => acc + BigInt(curr.estimated_shares),
+                BIGINT_ZERO,
+              )
+              const estimatedStake = BigInt(nominator.operator?.current_share_price) * totalShares
+              return estimatedStake > BIGINT_ZERO
+                ? acc + estimatedStake / SHARES_CALCULATION_MULTIPLIER
+                : acc
+            }, BIGINT_ZERO)
         : BIGINT_ZERO,
     [stakingSummary, subspaceAccount],
   )

--- a/explorer/src/components/WalletSideKick/query.gql
+++ b/explorer/src/components/WalletSideKick/query.gql
@@ -164,41 +164,12 @@ query StakingSummary($first: Int!, $subspaceAccount: String) {
       current_share_price
     }
     deposits {
-      id
-      amount
-      storage_fee_deposit
-      total_amount
       estimated_shares
-      timestamp
-      extrinsic_id
-      status
-      created_at
-      updated_at
     }
     withdrawals {
-      id
-      shares
-      storage_fee_refund
-      estimated_amount
       unlocked_amount
       unlocked_storage_fee
       total_amount
-      timestamp
-      withdraw_extrinsic_id
-      unlock_extrinsic_id
-      status
-      created_at
-      domain_block_number_ready_at
-      unlocked_at
-      updated_at
-    }
-    unlocked_events {
-      id
-      amount
-      storage_fee
-      # timestamp
-      block_height
-      extrinsic_id
     }
   }
   staking_nominators_aggregate(

--- a/explorer/src/components/WalletSideKick/query.gql
+++ b/explorer/src/components/WalletSideKick/query.gql
@@ -161,6 +161,44 @@ query StakingSummary($first: Int!, $subspaceAccount: String) {
       domain_id
       current_total_stake
       current_total_shares
+      current_share_price
+    }
+    deposits {
+      id
+      amount
+      storage_fee_deposit
+      total_amount
+      estimated_shares
+      timestamp
+      extrinsic_id
+      status
+      created_at
+      updated_at
+    }
+    withdrawals {
+      id
+      shares
+      storage_fee_refund
+      estimated_amount
+      unlocked_amount
+      unlocked_storage_fee
+      total_amount
+      timestamp
+      withdraw_extrinsic_id
+      unlock_extrinsic_id
+      status
+      created_at
+      domain_block_number_ready_at
+      unlocked_at
+      updated_at
+    }
+    unlocked_events {
+      id
+      amount
+      storage_fee
+      # timestamp
+      block_height
+      extrinsic_id
     }
   }
   staking_nominators_aggregate(


### PR DESCRIPTION
## Fix: Wallet sidekick staking summary

![image](https://github.com/user-attachments/assets/134eaa5f-66c5-4495-9f74-5db52b443cac)


As I was working on this and adding the same logic as the my nominations page, I'm realizing the stake amount logic is not valid since it does not remove what has been withdrawn, I'll create a new issue for this