### PR TITLE
Remove sortId in order by query

### DIFF
--- a/explorer/gql/graphql.tsx
+++ b/explorer/gql/graphql.tsx
@@ -3427,6 +3427,26 @@ export type Consensus_Rewards_Variance_Order_By = {
   block_height?: InputMaybe<Order_By>;
 };
 
+export type Consensus_Search_Block_Hash_Args = {
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Consensus_Search_Events_By_Block_Hash_Args = {
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Consensus_Search_Extrinsics_By_Block_Hash_Args = {
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Consensus_Search_Extrinsics_By_Hash_Args = {
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Consensus_Search_Hash_Args = {
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** columns and relationships of "consensus.sections" */
 export type Consensus_Sections = {
   __typename?: 'consensus_sections';
@@ -13904,6 +13924,26 @@ export type Query_Root = {
   consensus_rewards_aggregate: Consensus_Rewards_Aggregate;
   /** fetch data from the table: "consensus.rewards" using primary key columns */
   consensus_rewards_by_pk?: Maybe<Consensus_Rewards>;
+  /** execute function "consensus.search_block_hash" which returns "consensus.extrinsics" */
+  consensus_search_block_hash: Array<Consensus_Extrinsics>;
+  /** execute function "consensus.search_block_hash" and query aggregates on result of table type "consensus.extrinsics" */
+  consensus_search_block_hash_aggregate: Consensus_Extrinsics_Aggregate;
+  /** execute function "consensus.search_events_by_block_hash" which returns "consensus.events" */
+  consensus_search_events_by_block_hash: Array<Consensus_Events>;
+  /** execute function "consensus.search_events_by_block_hash" and query aggregates on result of table type "consensus.events" */
+  consensus_search_events_by_block_hash_aggregate: Consensus_Events_Aggregate;
+  /** execute function "consensus.search_extrinsics_by_block_hash" which returns "consensus.extrinsics" */
+  consensus_search_extrinsics_by_block_hash: Array<Consensus_Extrinsics>;
+  /** execute function "consensus.search_extrinsics_by_block_hash" and query aggregates on result of table type "consensus.extrinsics" */
+  consensus_search_extrinsics_by_block_hash_aggregate: Consensus_Extrinsics_Aggregate;
+  /** execute function "consensus.search_extrinsics_by_hash" which returns "consensus.extrinsics" */
+  consensus_search_extrinsics_by_hash: Array<Consensus_Extrinsics>;
+  /** execute function "consensus.search_extrinsics_by_hash" and query aggregates on result of table type "consensus.extrinsics" */
+  consensus_search_extrinsics_by_hash_aggregate: Consensus_Extrinsics_Aggregate;
+  /** execute function "consensus.search_hash" which returns "consensus.extrinsics" */
+  consensus_search_hash: Array<Consensus_Extrinsics>;
+  /** execute function "consensus.search_hash" and query aggregates on result of table type "consensus.extrinsics" */
+  consensus_search_hash_aggregate: Consensus_Extrinsics_Aggregate;
   /** fetch data from the table: "consensus.sections" */
   consensus_sections: Array<Consensus_Sections>;
   /** fetch aggregated fields from the table: "consensus.sections" */
@@ -14610,6 +14650,106 @@ export type Query_RootConsensus_Rewards_AggregateArgs = {
 
 export type Query_RootConsensus_Rewards_By_PkArgs = {
   uuid: Scalars['uuid']['input'];
+};
+
+
+export type Query_RootConsensus_Search_Block_HashArgs = {
+  args: Consensus_Search_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Search_Block_Hash_AggregateArgs = {
+  args: Consensus_Search_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Search_Events_By_Block_HashArgs = {
+  args: Consensus_Search_Events_By_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Events_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Events_Order_By>>;
+  where?: InputMaybe<Consensus_Events_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Search_Events_By_Block_Hash_AggregateArgs = {
+  args: Consensus_Search_Events_By_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Events_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Events_Order_By>>;
+  where?: InputMaybe<Consensus_Events_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Search_Extrinsics_By_Block_HashArgs = {
+  args: Consensus_Search_Extrinsics_By_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Search_Extrinsics_By_Block_Hash_AggregateArgs = {
+  args: Consensus_Search_Extrinsics_By_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Search_Extrinsics_By_HashArgs = {
+  args: Consensus_Search_Extrinsics_By_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Search_Extrinsics_By_Hash_AggregateArgs = {
+  args: Consensus_Search_Extrinsics_By_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Search_HashArgs = {
+  args: Consensus_Search_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Query_RootConsensus_Search_Hash_AggregateArgs = {
+  args: Consensus_Search_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
 };
 
 
@@ -23816,6 +23956,26 @@ export type Subscription_Root = {
   consensus_rewards_by_pk?: Maybe<Consensus_Rewards>;
   /** fetch data from the table in a streaming manner: "consensus.rewards" */
   consensus_rewards_stream: Array<Consensus_Rewards>;
+  /** execute function "consensus.search_block_hash" which returns "consensus.extrinsics" */
+  consensus_search_block_hash: Array<Consensus_Extrinsics>;
+  /** execute function "consensus.search_block_hash" and query aggregates on result of table type "consensus.extrinsics" */
+  consensus_search_block_hash_aggregate: Consensus_Extrinsics_Aggregate;
+  /** execute function "consensus.search_events_by_block_hash" which returns "consensus.events" */
+  consensus_search_events_by_block_hash: Array<Consensus_Events>;
+  /** execute function "consensus.search_events_by_block_hash" and query aggregates on result of table type "consensus.events" */
+  consensus_search_events_by_block_hash_aggregate: Consensus_Events_Aggregate;
+  /** execute function "consensus.search_extrinsics_by_block_hash" which returns "consensus.extrinsics" */
+  consensus_search_extrinsics_by_block_hash: Array<Consensus_Extrinsics>;
+  /** execute function "consensus.search_extrinsics_by_block_hash" and query aggregates on result of table type "consensus.extrinsics" */
+  consensus_search_extrinsics_by_block_hash_aggregate: Consensus_Extrinsics_Aggregate;
+  /** execute function "consensus.search_extrinsics_by_hash" which returns "consensus.extrinsics" */
+  consensus_search_extrinsics_by_hash: Array<Consensus_Extrinsics>;
+  /** execute function "consensus.search_extrinsics_by_hash" and query aggregates on result of table type "consensus.extrinsics" */
+  consensus_search_extrinsics_by_hash_aggregate: Consensus_Extrinsics_Aggregate;
+  /** execute function "consensus.search_hash" which returns "consensus.extrinsics" */
+  consensus_search_hash: Array<Consensus_Extrinsics>;
+  /** execute function "consensus.search_hash" and query aggregates on result of table type "consensus.extrinsics" */
+  consensus_search_hash_aggregate: Consensus_Extrinsics_Aggregate;
   /** fetch data from the table: "consensus.sections" */
   consensus_sections: Array<Consensus_Sections>;
   /** fetch aggregated fields from the table: "consensus.sections" */
@@ -24777,6 +24937,106 @@ export type Subscription_RootConsensus_Rewards_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Consensus_Rewards_Stream_Cursor_Input>>;
   where?: InputMaybe<Consensus_Rewards_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_Block_HashArgs = {
+  args: Consensus_Search_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_Block_Hash_AggregateArgs = {
+  args: Consensus_Search_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_Events_By_Block_HashArgs = {
+  args: Consensus_Search_Events_By_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Events_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Events_Order_By>>;
+  where?: InputMaybe<Consensus_Events_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_Events_By_Block_Hash_AggregateArgs = {
+  args: Consensus_Search_Events_By_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Events_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Events_Order_By>>;
+  where?: InputMaybe<Consensus_Events_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_Extrinsics_By_Block_HashArgs = {
+  args: Consensus_Search_Extrinsics_By_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_Extrinsics_By_Block_Hash_AggregateArgs = {
+  args: Consensus_Search_Extrinsics_By_Block_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_Extrinsics_By_HashArgs = {
+  args: Consensus_Search_Extrinsics_By_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_Extrinsics_By_Hash_AggregateArgs = {
+  args: Consensus_Search_Extrinsics_By_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_HashArgs = {
+  args: Consensus_Search_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
+};
+
+
+export type Subscription_RootConsensus_Search_Hash_AggregateArgs = {
+  args: Consensus_Search_Hash_Args;
+  distinct_on?: InputMaybe<Array<Consensus_Extrinsics_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Consensus_Extrinsics_Order_By>>;
+  where?: InputMaybe<Consensus_Extrinsics_Bool_Exp>;
 };
 
 

--- a/explorer/src/constants/tables.ts
+++ b/explorer/src/constants/tables.ts
@@ -427,7 +427,7 @@ export const INITIAL_TABLES: InitialTables = {
     },
     sorting: [
       {
-        id: BlocksColumns.SortId,
+        id: BlocksColumns.Height,
         desc: true,
       },
     ],
@@ -447,7 +447,11 @@ export const INITIAL_TABLES: InitialTables = {
     },
     sorting: [
       {
-        id: ExtrinsicsColumns.SortId,
+        id: ExtrinsicsColumns.BlockHeight,
+        desc: true,
+      },
+      {
+        id: ExtrinsicsColumns.IndexInBlock,
         desc: true,
       },
     ],
@@ -468,7 +472,11 @@ export const INITIAL_TABLES: InitialTables = {
     },
     sorting: [
       {
-        id: EventsColumns.SortId,
+        id: EventsColumns.BlockHeight,
+        desc: true,
+      },
+      {
+        id: EventsColumns.IndexInBlock,
         desc: true,
       },
     ],
@@ -488,7 +496,11 @@ export const INITIAL_TABLES: InitialTables = {
     },
     sorting: [
       {
-        id: LogsColumns.SortId,
+        id: LogsColumns.BlockHeight,
+        desc: true,
+      },
+      {
+        id: LogsColumns.IndexInBlock,
         desc: true,
       },
     ],

--- a/explorer/src/constants/tables.ts
+++ b/explorer/src/constants/tables.ts
@@ -26,7 +26,7 @@ export const AVAILABLE_COLUMNS: AvailableColumns = {
     { name: 'updatedAt', label: 'Updated At', isSelected: false },
   ],
   blocks: [
-    { name: 'sortId', label: 'Block number', isSelected: true, searchable: true },
+    { name: 'height', label: 'Block number', isSelected: true, searchable: true },
     { name: 'hash', label: 'Hash', isSelected: true, searchable: true },
     { name: 'timestamp', label: 'Time', isSelected: true },
     { name: 'parentHash', label: 'Parent Hash', isSelected: false, searchable: true },

--- a/explorer/src/constants/tables.ts
+++ b/explorer/src/constants/tables.ts
@@ -40,7 +40,7 @@ export const AVAILABLE_COLUMNS: AvailableColumns = {
     { name: 'authorId', label: 'Block Author', isSelected: true, searchable: true },
   ],
   extrinsics: [
-    { name: 'sortId', label: 'Extrinsic Id', isSelected: true },
+    { name: 'id', label: 'Extrinsic Id', isSelected: true },
     { name: 'hash', label: 'Extrinsic Hash', isSelected: true },
     { name: 'blockHeight', label: 'Block Height', isSelected: true },
     { name: 'module', label: 'Module', isSelected: true },
@@ -48,7 +48,7 @@ export const AVAILABLE_COLUMNS: AvailableColumns = {
     { name: 'timestamp', label: 'Time', isSelected: true },
   ],
   events: [
-    { name: 'sortId', label: 'Event Id', isSelected: true },
+    { name: 'id', label: 'Event Id', isSelected: true },
     { name: 'blockHeight', label: 'Block Height', isSelected: true },
     { name: 'extrinsicId', label: 'Extrinsic Id', isSelected: true },
     { name: 'module', label: 'Module', isSelected: true },
@@ -56,7 +56,7 @@ export const AVAILABLE_COLUMNS: AvailableColumns = {
     { name: 'timestamp', label: 'Time', isSelected: true },
   ],
   logs: [
-    { name: 'sortId', label: 'Log Id', isSelected: true, searchable: true },
+    { name: 'id', label: 'Log Id', isSelected: true, searchable: true },
     { name: 'blockHeight', label: 'Block Height', isSelected: true, searchable: true },
     { name: 'blockHash', label: 'Block Hash', isSelected: true, searchable: true },
     { name: 'indexInBlock', label: 'Index in Block', isSelected: true },


### PR DESCRIPTION
## Remove sortId in order by query

Completely removing `sort_id` at this time will cause table sorting by id on extrinsic and event table to break.