### PR TITLE
Fix: Extrinsics not loading when block page is accessed via hash

### DIFF
--- a/explorer/gql/graphql.tsx
+++ b/explorer/gql/graphql.tsx
@@ -27372,7 +27372,7 @@ export type BlockByIdQueryVariables = Exact<{
 export type BlockByIdQuery = { __typename?: 'query_root', consensus_blocks: Array<{ __typename?: 'consensus_blocks', id: string, height: any, hash: string, state_root: string, timestamp: any, extrinsics_root: string, spec_id: string, parent_hash: string, extrinsics_count: number, events_count: number, logs_count: number, author_id: string }> };
 
 export type ExtrinsicsByBlockIdQueryVariables = Exact<{
-  blockId: Scalars['numeric']['input'];
+  blockHeight: Scalars['numeric']['input'];
   limit: Scalars['Int']['input'];
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<Consensus_Extrinsics_Order_By> | Consensus_Extrinsics_Order_By>;
@@ -27382,7 +27382,7 @@ export type ExtrinsicsByBlockIdQueryVariables = Exact<{
 export type ExtrinsicsByBlockIdQuery = { __typename?: 'query_root', consensus_extrinsics: Array<{ __typename?: 'consensus_extrinsics', id: string, hash: string, section: string, module: string, success: boolean }> };
 
 export type EventsByBlockIdQueryVariables = Exact<{
-  blockId: Scalars['numeric']['input'];
+  blockHeight: Scalars['numeric']['input'];
   limit: Scalars['Int']['input'];
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<Consensus_Events_Order_By> | Consensus_Events_Order_By>;
@@ -27392,7 +27392,7 @@ export type EventsByBlockIdQueryVariables = Exact<{
 export type EventsByBlockIdQuery = { __typename?: 'query_root', consensus_events: Array<{ __typename?: 'consensus_events', id: string, section: string, module: string, phase: string, extrinsic_id: string }> };
 
 export type LogsByBlockIdQueryVariables = Exact<{
-  blockId: Scalars['numeric']['input'];
+  blockHeight: Scalars['numeric']['input'];
   limit: Scalars['Int']['input'];
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<Consensus_Logs_Order_By> | Consensus_Logs_Order_By>;
@@ -28539,12 +28539,12 @@ export type BlockByIdLazyQueryHookResult = ReturnType<typeof useBlockByIdLazyQue
 export type BlockByIdSuspenseQueryHookResult = ReturnType<typeof useBlockByIdSuspenseQuery>;
 export type BlockByIdQueryResult = Apollo.QueryResult<BlockByIdQuery, BlockByIdQueryVariables>;
 export const ExtrinsicsByBlockIdDocument = gql`
-    query ExtrinsicsByBlockId($blockId: numeric!, $limit: Int!, $offset: Int, $orderBy: [consensus_extrinsics_order_by!]) {
+    query ExtrinsicsByBlockId($blockHeight: numeric!, $limit: Int!, $offset: Int, $orderBy: [consensus_extrinsics_order_by!]) {
   consensus_extrinsics(
     order_by: $orderBy
     limit: $limit
     offset: $offset
-    where: {block_height: {_eq: $blockId}}
+    where: {block_height: {_eq: $blockHeight}}
   ) {
     id
     hash
@@ -28567,7 +28567,7 @@ export const ExtrinsicsByBlockIdDocument = gql`
  * @example
  * const { data, loading, error } = useExtrinsicsByBlockIdQuery({
  *   variables: {
- *      blockId: // value for 'blockId'
+ *      blockHeight: // value for 'blockHeight'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      orderBy: // value for 'orderBy'
@@ -28591,12 +28591,12 @@ export type ExtrinsicsByBlockIdLazyQueryHookResult = ReturnType<typeof useExtrin
 export type ExtrinsicsByBlockIdSuspenseQueryHookResult = ReturnType<typeof useExtrinsicsByBlockIdSuspenseQuery>;
 export type ExtrinsicsByBlockIdQueryResult = Apollo.QueryResult<ExtrinsicsByBlockIdQuery, ExtrinsicsByBlockIdQueryVariables>;
 export const EventsByBlockIdDocument = gql`
-    query EventsByBlockId($blockId: numeric!, $limit: Int!, $offset: Int, $orderBy: [consensus_events_order_by!]) {
+    query EventsByBlockId($blockHeight: numeric!, $limit: Int!, $offset: Int, $orderBy: [consensus_events_order_by!]) {
   consensus_events(
     order_by: $orderBy
     limit: $limit
     offset: $offset
-    where: {block_height: {_eq: $blockId}}
+    where: {block_height: {_eq: $blockHeight}}
   ) {
     id
     section
@@ -28619,7 +28619,7 @@ export const EventsByBlockIdDocument = gql`
  * @example
  * const { data, loading, error } = useEventsByBlockIdQuery({
  *   variables: {
- *      blockId: // value for 'blockId'
+ *      blockHeight: // value for 'blockHeight'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      orderBy: // value for 'orderBy'
@@ -28643,12 +28643,12 @@ export type EventsByBlockIdLazyQueryHookResult = ReturnType<typeof useEventsByBl
 export type EventsByBlockIdSuspenseQueryHookResult = ReturnType<typeof useEventsByBlockIdSuspenseQuery>;
 export type EventsByBlockIdQueryResult = Apollo.QueryResult<EventsByBlockIdQuery, EventsByBlockIdQueryVariables>;
 export const LogsByBlockIdDocument = gql`
-    query LogsByBlockId($blockId: numeric!, $limit: Int!, $offset: Int, $orderBy: [consensus_logs_order_by!]) {
+    query LogsByBlockId($blockHeight: numeric!, $limit: Int!, $offset: Int, $orderBy: [consensus_logs_order_by!]) {
   consensus_logs(
     order_by: $orderBy
     limit: $limit
     offset: $offset
-    where: {block_height: {_eq: $blockId}}
+    where: {block_height: {_eq: $blockHeight}}
   ) {
     id
     kind
@@ -28669,7 +28669,7 @@ export const LogsByBlockIdDocument = gql`
  * @example
  * const { data, loading, error } = useLogsByBlockIdQuery({
  *   variables: {
- *      blockId: // value for 'blockId'
+ *      blockHeight: // value for 'blockHeight'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      orderBy: // value for 'orderBy'

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -17,6 +17,7 @@
   "engines": {
     "node": ">=20.19.0"
   },
+  "packageManager": "yarn@1.22.19",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/explorer/src/components/Consensus/Block/Block.tsx
+++ b/explorer/src/components/Consensus/Block/Block.tsx
@@ -56,6 +56,7 @@ export const Block: FC = () => {
           <>
             <BlockDetailsCard block={block} isDesktop={isDesktop} />
             <BlockDetailsTabs
+              blockHeight={block.height}
               extrinsicsCount={block.extrinsics_count}
               eventsCount={block.events_count}
               logsCount={block.logs_count}

--- a/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
@@ -16,7 +16,6 @@ import useIndexers from 'hooks/useIndexers'
 import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
-import { useParams } from 'next/navigation'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { hasValue, isLoading, useQueryStates } from 'states/query'
@@ -28,12 +27,12 @@ import { NotFound } from '../../layout/NotFound'
 type Row = EventsByBlockIdQuery['consensus_events'][number]
 
 type Props = {
+  blockHeight: number
   eventsCount: number
 }
 
-export const BlockDetailsEventList: FC<Props> = ({ eventsCount }) => {
+export const BlockDetailsEventList: FC<Props> = ({ blockHeight, eventsCount }) => {
   const { ref, inView } = useInView()
-  const { blockId } = useParams()
   const { network, section } = useIndexers()
   const apolloClient = useApolloClient()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'sort_id', desc: false }])
@@ -59,9 +58,9 @@ export const BlockDetailsEventList: FC<Props> = ({ eventsCount }) => {
       limit: pagination.pageSize,
       offset: pagination.pageIndex > 0 ? pagination.pageIndex * pagination.pageSize : undefined,
       orderBy,
-      blockId: Number(blockId),
+      blockId: blockHeight,
     }),
-    [pagination.pageSize, pagination.pageIndex, orderBy, blockId],
+    [pagination.pageSize, pagination.pageIndex, orderBy, blockHeight],
   )
 
   const { loading, setIsVisible } = useIndexersQuery<

--- a/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsEventList.tsx
@@ -58,7 +58,7 @@ export const BlockDetailsEventList: FC<Props> = ({ blockHeight, eventsCount }) =
       limit: pagination.pageSize,
       offset: pagination.pageIndex > 0 ? pagination.pageIndex * pagination.pageSize : undefined,
       orderBy,
-      blockId: blockHeight,
+      blockHeight,
     }),
     [pagination.pageSize, pagination.pageIndex, orderBy, blockHeight],
   )

--- a/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
@@ -18,7 +18,6 @@ import useIndexers from 'hooks/useIndexers'
 import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
-import { useParams } from 'next/navigation'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { hasValue, isLoading, useQueryStates } from 'states/query'
@@ -28,15 +27,19 @@ import { countTablePages } from 'utils/table'
 import { NotFound } from '../../layout/NotFound'
 
 type Props = {
+  blockHeight: number
   extrinsicsCount: number
   isDesktop?: boolean
 }
 
 type Row = ExtrinsicsByBlockIdQuery['consensus_extrinsics'][number]
 
-export const BlockDetailsExtrinsicList: FC<Props> = ({ extrinsicsCount, isDesktop = false }) => {
+export const BlockDetailsExtrinsicList: FC<Props> = ({
+  blockHeight,
+  extrinsicsCount,
+  isDesktop = false,
+}) => {
   const { ref, inView } = useInView()
-  const { blockId } = useParams()
   const { network, section } = useIndexers()
   const apolloClient = useApolloClient()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'sort_id', desc: false }])
@@ -62,9 +65,9 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({ extrinsicsCount, isDeskto
       limit: pagination.pageSize,
       offset: pagination.pageIndex > 0 ? pagination.pageIndex * pagination.pageSize : undefined,
       orderBy,
-      blockId: Number(blockId),
+      blockId: blockHeight,
     }),
-    [pagination.pageSize, pagination.pageIndex, orderBy, blockId],
+    [pagination.pageSize, pagination.pageIndex, orderBy, blockHeight],
   )
 
   const { loading, setIsVisible } = useIndexersQuery<

--- a/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsExtrinsicList.tsx
@@ -65,7 +65,7 @@ export const BlockDetailsExtrinsicList: FC<Props> = ({
       limit: pagination.pageSize,
       offset: pagination.pageIndex > 0 ? pagination.pageIndex * pagination.pageSize : undefined,
       orderBy,
-      blockId: blockHeight,
+      blockHeight,
     }),
     [pagination.pageSize, pagination.pageIndex, orderBy, blockHeight],
   )

--- a/explorer/src/components/Consensus/Block/BlockDetailsLogList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsLogList.tsx
@@ -17,7 +17,6 @@ import useIndexers from 'hooks/useIndexers'
 import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
-import { useParams } from 'next/navigation'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { hasValue, isLoading, useQueryStates } from 'states/query'
@@ -28,12 +27,12 @@ import { countTablePages } from 'utils/table'
 type Row = LogsByBlockIdQuery['consensus_logs'][number]
 
 type Props = {
+  blockHeight: number
   logsCount: number
 }
 
-export const BlockDetailsLogList: FC<Props> = ({ logsCount }) => {
+export const BlockDetailsLogList: FC<Props> = ({ blockHeight, logsCount }) => {
   const { ref, inView } = useInView()
-  const { blockId } = useParams()
   const { network, section } = useIndexers()
   const apolloClient = useApolloClient()
   const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
@@ -59,9 +58,9 @@ export const BlockDetailsLogList: FC<Props> = ({ logsCount }) => {
       limit: pagination.pageSize,
       offset: pagination.pageIndex > 0 ? pagination.pageIndex * pagination.pageSize : undefined,
       orderBy,
-      blockId: Number(blockId),
+      blockId: blockHeight,
     }),
-    [pagination.pageSize, pagination.pageIndex, orderBy, blockId],
+    [pagination.pageSize, pagination.pageIndex, orderBy, blockHeight],
   )
 
   const { loading, setIsVisible } = useIndexersQuery<

--- a/explorer/src/components/Consensus/Block/BlockDetailsLogList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsLogList.tsx
@@ -58,7 +58,7 @@ export const BlockDetailsLogList: FC<Props> = ({ blockHeight, logsCount }) => {
       limit: pagination.pageSize,
       offset: pagination.pageIndex > 0 ? pagination.pageIndex * pagination.pageSize : undefined,
       orderBy,
-      blockId: blockHeight,
+      blockHeight,
     }),
     [pagination.pageSize, pagination.pageIndex, orderBy, blockHeight],
   )

--- a/explorer/src/components/Consensus/Block/BlockDetailsTabs.tsx
+++ b/explorer/src/components/Consensus/Block/BlockDetailsTabs.tsx
@@ -6,6 +6,7 @@ import { BlockDetailsExtrinsicList } from './BlockDetailsExtrinsicList'
 import { BlockDetailsLogList } from './BlockDetailsLogList'
 
 type Props = {
+  blockHeight: number
   extrinsicsCount: number
   eventsCount: number
   logsCount: number
@@ -13,6 +14,7 @@ type Props = {
 }
 
 export const BlockDetailsTabs: FC<Props> = ({
+  blockHeight,
   extrinsicsCount,
   eventsCount,
   logsCount,
@@ -21,13 +23,17 @@ export const BlockDetailsTabs: FC<Props> = ({
   return (
     <PageTabs pillStyle='py-2' activePillStyle='py-2' isDesktop={isDesktop}>
       <Tab title={`Extrinsics (${extrinsicsCount})`}>
-        <BlockDetailsExtrinsicList extrinsicsCount={extrinsicsCount} isDesktop={isDesktop} />
+        <BlockDetailsExtrinsicList
+          blockHeight={blockHeight}
+          extrinsicsCount={extrinsicsCount}
+          isDesktop={isDesktop}
+        />
       </Tab>
       <Tab title={`Events (${eventsCount})`}>
-        <BlockDetailsEventList eventsCount={eventsCount} />
+        <BlockDetailsEventList blockHeight={blockHeight} eventsCount={eventsCount} />
       </Tab>
       <Tab title={`Logs (${logsCount})`}>
-        <BlockDetailsLogList logsCount={logsCount} />
+        <BlockDetailsLogList blockHeight={blockHeight} logsCount={logsCount} />
       </Tab>
     </PageTabs>
   )

--- a/explorer/src/components/Consensus/Block/query.gql
+++ b/explorer/src/components/Consensus/Block/query.gql
@@ -44,7 +44,7 @@ query BlockById($blockId: String!, $blockHash: String!) {
 }
 
 query ExtrinsicsByBlockId(
-  $blockId: numeric!
+  $blockHeight: numeric!
   $limit: Int!
   $offset: Int
   $orderBy: [consensus_extrinsics_order_by!]
@@ -53,7 +53,7 @@ query ExtrinsicsByBlockId(
     order_by: $orderBy
     limit: $limit
     offset: $offset
-    where: { block_height: { _eq: $blockId } }
+    where: { block_height: { _eq: $blockHeight } }
   ) {
     id
     hash
@@ -64,7 +64,7 @@ query ExtrinsicsByBlockId(
 }
 
 query EventsByBlockId(
-  $blockId: numeric!
+  $blockHeight: numeric!
   $limit: Int!
   $offset: Int
   $orderBy: [consensus_events_order_by!]
@@ -73,7 +73,7 @@ query EventsByBlockId(
     order_by: $orderBy
     limit: $limit
     offset: $offset
-    where: { block_height: { _eq: $blockId } }
+    where: { block_height: { _eq: $blockHeight } }
   ) {
     id
     section
@@ -84,7 +84,7 @@ query EventsByBlockId(
 }
 
 query LogsByBlockId(
-  $blockId: numeric!
+  $blockHeight: numeric!
   $limit: Int!
   $offset: Int
   $orderBy: [consensus_logs_order_by!]
@@ -93,7 +93,7 @@ query LogsByBlockId(
     order_by: $orderBy
     limit: $limit
     offset: $offset
-    where: { block_height: { _eq: $blockId } }
+    where: { block_height: { _eq: $blockHeight } }
   ) {
     id
     kind


### PR DESCRIPTION
## Summary

This PR fixes an issue where extrinsics, events, and logs were not loading when accessing a block page using a block hash instead of a block number.

## Problem

When navigating to a block page using a hash (e.g., `/blocks/0x3073fc4f3406dd4f0a8babe903ea9dde901cf15d85663a52f9e4f8d86fe1393f`), the child components were attempting to convert the hash string to a number using `Number(blockId)`, which resulted in a nonsensical float value like `2.1915945519840543e+76`. This caused the GraphQL queries to fail as they were filtering by `block_height` with an invalid value.

## Solution

The fix passes the actual numeric `block.height` value from the parent `Block` component to the child components through props, ensuring they always have the correct block height regardless of how the page was accessed.

### Changes Made:

1. **Updated `BlockDetailsTabs`** to accept and pass `blockHeight` prop to child components
2. **Updated `BlockDetailsExtrinsicList`** to use `blockHeight` prop instead of parsing URL params
3. **Updated `BlockDetailsEventList`** to use `blockHeight` prop instead of parsing URL params
4. **Updated `BlockDetailsLogList`** to use `blockHeight` prop instead of parsing URL params
5. **Updated `Block`** component to pass `block.height` to `BlockDetailsTabs`
6. Removed unused `useParams` imports from the child components
7. Unrelated to the PR, added yarn version to package.json

## Testing

- ✅ Accessing block page by number: `/blocks/2652156` - extrinsics load correctly
- ✅ Accessing block page by hash: `/blocks/0x3073fc4f3406dd4f0a8babe903ea9dde901cf15d85663a52f9e4f8d86fe1393f` - extrinsics now load correctly
- ✅ TypeScript compilation passes without errors

## Related Issue

Fixes #1601
