### PR TITLE
Improve Block Search UX with Direct Navigation

### DIFF
--- a/explorer/src/components/Consensus/Block/BlockList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockList.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { formatSpaceToDecimal } from '@autonomys/auto-consensus'
-import { shortString } from '@autonomys/auto-utils'
+import { isHex, shortString } from '@autonomys/auto-utils'
 import { AccountIconWithLink } from 'components/common/AccountIcon'
 import { CopyButton } from 'components/common/CopyButton'
 import { SortedTable } from 'components/common/SortedTable'
@@ -14,7 +14,8 @@ import useIndexers from 'hooks/useIndexers'
 import { useIndexersQuery } from 'hooks/useIndexersQuery'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
-import { FC, useEffect, useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import { FC, useCallback, useEffect, useMemo } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { hasValue, isLoading, useQueryStates } from 'states/query'
 import { useTableSettings } from 'states/tables'
@@ -27,7 +28,8 @@ const TABLE = 'blocks'
 
 export const BlockList: FC = () => {
   const { ref, inView } = useInView()
-  const { network, section } = useIndexers()
+  const { network } = useIndexers()
+  const { push } = useRouter()
   const inFocus = useWindowFocus()
   const {
     pagination,
@@ -39,6 +41,37 @@ export const BlockList: FC = () => {
     onPaginationChange,
     onSortingChange,
   } = useTableSettings<BlocksFilters>(TABLE)
+
+  // Handle custom search for unique identifiers
+  const handleSearchSubmit = useCallback(
+    (columnName: string, value: string): boolean => {
+      if (value.trim()) {
+        // Block height search - navigate directly
+        if (columnName === 'height') {
+          const blockNumber = Number(value.trim())
+          if (!isNaN(blockNumber) && blockNumber >= 0) {
+            push(INTERNAL_ROUTES.blocks.id.page(network, Routes.consensus, blockNumber))
+            return true // Handled
+          }
+        }
+
+        // Hash search - navigate directly
+        if (columnName === 'hash' && isHex(value.trim())) {
+          push(INTERNAL_ROUTES.blocks.hash.page(network, Routes.consensus, value.trim()))
+          return true // Handled
+        }
+
+        // Parent hash search - navigate directly
+        if (columnName === 'parentHash' && isHex(value.trim())) {
+          push(INTERNAL_ROUTES.blocks.hash.page(network, Routes.consensus, value.trim()))
+          return true // Handled
+        }
+      }
+
+      return false // Not handled, use default behavior
+    },
+    [network, push],
+  )
 
   const where = useMemo(
     () => ({
@@ -122,7 +155,7 @@ export const BlockList: FC = () => {
             key={`${row.index}-block-height`}
             data-testid={`block-link-${row.index}`}
             className='hover:text-primaryAccent'
-            href={INTERNAL_ROUTES.blocks.id.page(network, section, row.original.height)}
+            href={INTERNAL_ROUTES.blocks.id.page(network, Routes.consensus, row.original.height)}
           >
             <div>{row.original.id}</div>
           </Link>
@@ -144,7 +177,7 @@ export const BlockList: FC = () => {
           <AccountIconWithLink
             address={row.original.authorId}
             network={network}
-            section={section}
+            section={Routes.consensus}
           />
         ),
         specId: ({ row }: Cell<Row>) => row.original.specId,
@@ -161,7 +194,7 @@ export const BlockList: FC = () => {
         spacePledged: ({ row }: Cell<Row>) => formatSpaceToDecimal(row.original.spacePledged),
         blockchainSize: ({ row }: Cell<Row>) => formatSpaceToDecimal(row.original.blockchainSize),
       }),
-    [network, section, selectedColumns],
+    [network, selectedColumns],
   )
 
   const pageCount = useMemo(
@@ -182,7 +215,12 @@ export const BlockList: FC = () => {
   return (
     <div className='flex w-full flex-col align-middle'>
       <div className='my-4' ref={ref}>
-        <TableSettings table={TABLE} totalCount={totalCount} filters={filters} />
+        <TableSettings
+          table={TABLE}
+          totalCount={totalCount}
+          filters={filters as BlocksFilters & Record<string, string | undefined>}
+          onSearchSubmit={handleSearchSubmit}
+        />
         {!loading && blocks ? (
           <SortedTable
             data={blocks}

--- a/explorer/src/components/common/TableSettings.tsx
+++ b/explorer/src/components/common/TableSettings.tsx
@@ -6,7 +6,7 @@ import {
   PencilIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { TableName, useTableSettings } from 'states/tables'
 import { FilterOption } from 'types/table'
 import { numberWithCommas } from 'utils/number'
@@ -19,6 +19,7 @@ interface TableSettingsProps {
   filters: Record<string, any>
   addExtraIcons?: React.ReactNode
   overrideFiltersOptions?: FilterOption[]
+  onSearchSubmit?: (columnName: string, value: string) => boolean // Returns true if handled
 }
 
 export const TableSettings: React.FC<TableSettingsProps> = ({
@@ -28,8 +29,12 @@ export const TableSettings: React.FC<TableSettingsProps> = ({
   filters,
   addExtraIcons,
   overrideFiltersOptions,
+  onSearchSubmit,
 }) => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  // Local state for search inputs when using custom search
+  const [searchValues, setSearchValues] = useState<Record<string, string>>({})
+
   if (!tableName) {
     tableName = capitalizeFirstLetter(table)
   }
@@ -58,6 +63,44 @@ export const TableSettings: React.FC<TableSettingsProps> = ({
   const isAvailableFilters = useMemo(() => {
     return filtersOptions?.some((filter) => filter.type !== 'range' && filter.type !== 'checkbox')
   }, [filtersOptions])
+
+  // Initialize search values from filters when using custom search
+  useEffect(() => {
+    if (onSearchSubmit) {
+      const initialValues: Record<string, string> = {}
+      availableColumns?.forEach((column) => {
+        if (column.searchable) {
+          const filterValue = filters[`search-${column.name}`]
+          if (filterValue) {
+            initialValues[column.name] = filterValue
+          }
+        }
+      })
+      setSearchValues(initialValues)
+    }
+  }, [availableColumns, filters, onSearchSubmit])
+
+  // Handle search submit
+  const handleSearchSubmit = useCallback(
+    (e: React.FormEvent, columnName: string) => {
+      e.preventDefault()
+      const value = searchValues[columnName] || ''
+
+      // If custom handler is provided and it handles the search, don't update filters
+      if (onSearchSubmit && onSearchSubmit(columnName, value)) {
+        return
+      }
+
+      // Otherwise, update filters normally
+      handleFilterChange(`search-${columnName}`, value)
+    },
+    [searchValues, onSearchSubmit, handleFilterChange],
+  )
+
+  // Handle search input change
+  const handleSearchInputChange = useCallback((columnName: string, value: string) => {
+    setSearchValues((prev) => ({ ...prev, [columnName]: value }))
+  }, [])
 
   return (
     <div className='mb-4 w-full' id='accordion-open' data-accordion='open'>
@@ -142,26 +185,50 @@ export const TableSettings: React.FC<TableSettingsProps> = ({
                         {availableColumns &&
                           availableColumns
                             .filter((column) => column.searchable)
-                            .map((column) => (
-                              <div key={column.name}>
-                                <label
-                                  htmlFor={`search-${column.name}`}
-                                  className='mb-1 block font-medium'
+                            .map((column) =>
+                              onSearchSubmit ? (
+                                <form
+                                  key={column.name}
+                                  onSubmit={(e) => handleSearchSubmit(e, column.name)}
                                 >
-                                  {column.label}
-                                </label>
-                                <input
-                                  id={`search-${column.name}`}
-                                  type='text'
-                                  placeholder={`Search by ${column.label}`}
-                                  className='w-full rounded border p-2 dark:bg-blueAccent dark:text-white'
-                                  value={filters[`search-${column.name}`] || ''}
-                                  onChange={(e) =>
-                                    handleFilterChange(`search-${column.name}`, e.target.value)
-                                  }
-                                />
-                              </div>
-                            ))}
+                                  <label
+                                    htmlFor={`search-${column.name}`}
+                                    className='mb-1 block font-medium'
+                                  >
+                                    {column.label}
+                                  </label>
+                                  <input
+                                    id={`search-${column.name}`}
+                                    type='text'
+                                    placeholder={`Search by ${column.label}`}
+                                    className='w-full rounded border p-2 dark:bg-blueAccent dark:text-white'
+                                    value={searchValues[column.name] || ''}
+                                    onChange={(e) =>
+                                      handleSearchInputChange(column.name, e.target.value)
+                                    }
+                                  />
+                                </form>
+                              ) : (
+                                <div key={column.name}>
+                                  <label
+                                    htmlFor={`search-${column.name}`}
+                                    className='mb-1 block font-medium'
+                                  >
+                                    {column.label}
+                                  </label>
+                                  <input
+                                    id={`search-${column.name}`}
+                                    type='text'
+                                    placeholder={`Search by ${column.label}`}
+                                    className='w-full rounded border p-2 dark:bg-blueAccent dark:text-white'
+                                    value={filters[`search-${column.name}`] || ''}
+                                    onChange={(e) =>
+                                      handleFilterChange(`search-${column.name}`, e.target.value)
+                                    }
+                                  />
+                                </div>
+                              ),
+                            )}
                       </div>
                     </div>
                   </>


### PR DESCRIPTION
## Summary

This PR enhances the user experience for searching blocks by implementing direct navigation to individual block pages when searching by unique identifiers (block number, hash, or parent hash), while maintaining table filtering for non-unique identifiers like author.

## Problem

Previously, when searching in the BlockList table:

- All searches would filter the table, even for unique identifiers
- Searching by block number, hash, or parent hash would show a filtered table with one result
- Users had to click on that single result to view the block details
- This created an unnecessary extra step for unique identifier searches

## Solution

### 1. Extended TableSettings Component

- Added optional `onSearchSubmit` prop to allow custom search behavior
- Implemented controlled inputs with form submission (Enter key) when custom handler is provided
- Maintains backward compatibility - existing tables work without changes

### 2. Custom Search Handler for Blocks

- Block height → Navigate directly to `/consensus/blocks/{number}`
- Hash → Navigate directly to `/consensus/blocks/{hash}`
- Parent hash → Navigate directly to `/consensus/blocks/{hash}`
- Author → Filter the table (multiple results possible)

### 3. Improved UX

- All searches now require pressing Enter (no more instant filtering on every keystroke)
- Unique identifiers navigate immediately, saving a click
- Non-unique identifiers (author) still filter the table as expected
- Proper browser history maintained for back button navigation

