### PR TITLE
refactor: 🔨 remove space pledged/history size from block details

### DIFF
--- a/explorer/gql/graphql.tsx
+++ b/explorer/gql/graphql.tsx
@@ -27361,7 +27361,7 @@ export type BlocksQueryVariables = Exact<{
 }>;
 
 
-export type BlocksQuery = { __typename?: 'query_root', consensus_blocks_aggregate: { __typename?: 'consensus_blocks_aggregate', aggregate?: { __typename?: 'consensus_blocks_aggregate_fields', count: number } | null }, consensus_blocks: Array<{ __typename?: 'consensus_blocks', id: string, height: any, hash: string, timestamp: any, parentHash: string, specId: string, stateRoot: string, extrinsicsRoot: string, spacePledged: any, blockchainSize: any, extrinsicsCount: number, eventsCount: number, authorId: string }> };
+export type BlocksQuery = { __typename?: 'query_root', consensus_blocks_aggregate: { __typename?: 'consensus_blocks_aggregate', aggregate?: { __typename?: 'consensus_blocks_aggregate_fields', count: number } | null }, consensus_blocks: Array<{ __typename?: 'consensus_blocks', id: string, height: any, hash: string, timestamp: any, parentHash: string, specId: string, stateRoot: string, extrinsicsRoot: string, extrinsicsCount: number, eventsCount: number, authorId: string }> };
 
 export type BlockByIdQueryVariables = Exact<{
   blockId: Scalars['String']['input'];
@@ -27493,7 +27493,7 @@ export type HomeQueryVariables = Exact<{
 }>;
 
 
-export type HomeQuery = { __typename?: 'query_root', consensus_blocks: Array<{ __typename?: 'consensus_blocks', id: string, height: any, timestamp: any, extrinsics_count: number, events_count: number, space_pledged: any, blockchain_size: any, extrinsicsCount: number, extrinsics: Array<{ __typename?: 'consensus_extrinsics', id: string, hash: string, block_height: any, name: string, timestamp: any, success: boolean }>, cumulative?: { __typename?: 'consensus_cumulative_blocks', cumulative_extrinsics_count: any, cumulative_events_count: any, cumulative_transfers_count: any, cumulative_transfer_value: any, cumulative_rewards_count: any, cumulative_reward_value: any } | null }>, consensus_accounts_aggregate: { __typename?: 'consensus_accounts_aggregate', aggregate?: { __typename?: 'consensus_accounts_aggregate_fields', count: number } | null } };
+export type HomeQuery = { __typename?: 'query_root', consensus_blocks: Array<{ __typename?: 'consensus_blocks', id: string, height: any, timestamp: any, extrinsics_count: number, events_count: number, extrinsicsCount: number, extrinsics: Array<{ __typename?: 'consensus_extrinsics', id: string, hash: string, block_height: any, name: string, timestamp: any, success: boolean }>, cumulative?: { __typename?: 'consensus_cumulative_blocks', cumulative_extrinsics_count: any, cumulative_events_count: any, cumulative_transfers_count: any, cumulative_transfer_value: any, cumulative_rewards_count: any, cumulative_reward_value: any } | null }>, consensus_accounts_aggregate: { __typename?: 'consensus_accounts_aggregate', aggregate?: { __typename?: 'consensus_accounts_aggregate_fields', count: number } | null } };
 
 export type OnChainActivityChartsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -28458,8 +28458,6 @@ export const BlocksDocument = gql`
     specId: spec_id
     stateRoot: state_root
     extrinsicsRoot: extrinsics_root
-    spacePledged: space_pledged
-    blockchainSize: blockchain_size
     extrinsicsCount: extrinsics_count
     eventsCount: events_count
     authorId: author_id
@@ -29229,8 +29227,6 @@ export const HomeDocument = gql`
     timestamp
     extrinsics_count
     events_count
-    space_pledged
-    blockchain_size
     extrinsicsCount: extrinsics_count
     extrinsics(limit: $limit, offset: $offset, order_by: {sort_id: desc}) {
       id

--- a/explorer/src/app/[chain]/consensus/image/route.tsx
+++ b/explorer/src/app/[chain]/consensus/image/route.tsx
@@ -1,9 +1,6 @@
 /* eslint-disable react/no-unknown-property */
-import { formatSpaceToDecimal } from '@autonomys/auto-consensus'
-import { ArchivedHistoryIcon } from 'components/icons/ArchivedHistoryIcon'
 import { AutonomysSymbol } from 'components/icons/AutonomysSymbol'
 import { BlockIcon } from 'components/icons/BlockIcon'
-import { DocIcon } from 'components/icons/DocIcon'
 import { WalletIcon } from 'components/icons/WalletIcon'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
@@ -53,8 +50,6 @@ function Screen({ chainMatch, data }: { chainMatch: (typeof indexers)[number]; d
   const block = {
     height: data.consensus_blocks[0]?.height ?? '0',
     accountsCount: data.consensus_accounts_aggregate.aggregate?.count ?? 0,
-    spacePledged: data.consensus_blocks[0]?.space_pledged ?? '',
-    historySize: data.consensus_blocks[0]?.blockchain_size ?? '',
   }
   const title = `${metadata.title} - ${chainMatch.title}`
 
@@ -118,42 +113,6 @@ function Screen({ chainMatch, data }: { chainMatch: (typeof indexers)[number]; d
               tw='absolute text-2xl text-white p-4 ml-30 font-bold'
             >
               Accounts {numberWithCommas(block.accountsCount)}
-            </span>
-          </div>
-        </div>
-        <div
-          tw='absolute flex flex-row border-none rounded-[20px] ml-140 mt-60 mb-4 p-6 w-130 h-30'
-          style={{
-            background: 'linear-gradient(180deg, #032372 0%, #1949D2 100%)',
-          }}
-        >
-          <div tw='absolute flex flex-col w-130 m-6'>
-            <DocIcon />
-            <span
-              style={{
-                fontFamily: 'Montserrat',
-              }}
-              tw='absolute text-2xl text-white p-4 ml-30 font-bold'
-            >
-              Space Pledged {formatSpaceToDecimal(block.spacePledged)}
-            </span>
-          </div>
-        </div>
-        <div
-          tw='absolute flex flex-row border-none rounded-[20px] ml-140 mt-100 mb-1 p-6 w-130 h-30'
-          style={{
-            background: 'linear-gradient(180deg, #032372 0%, #1949D2 100%)',
-          }}
-        >
-          <div tw='absolute flex flex-col w-130 m-6'>
-            <ArchivedHistoryIcon />
-            <span
-              style={{
-                fontFamily: 'Montserrat',
-              }}
-              tw='absolute text-2xl text-white p-4 ml-30 font-bold'
-            >
-              History Size {formatSpaceToDecimal(block.historySize)}
             </span>
           </div>
         </div>

--- a/explorer/src/app/[chain]/image/route.tsx
+++ b/explorer/src/app/[chain]/image/route.tsx
@@ -1,9 +1,7 @@
 /* eslint-disable react/no-unknown-property */
-import { formatSpaceToDecimal } from '@autonomys/auto-consensus'
 import { AutonomysSymbol } from 'components/icons/AutonomysSymbol'
 import { BlockIcon } from 'components/icons/BlockIcon'
 import { LogoIcon } from 'components/icons/LogoIcon'
-import { PieChartIcon } from 'components/icons/PieChartIcon'
 import { WalletIcon } from 'components/icons/WalletIcon'
 import { indexers } from 'constants/indexers'
 import { metadata } from 'constants/metadata'
@@ -130,37 +128,6 @@ function Screen({ chainMatch, data }: { chainMatch: (typeof indexers)[number]; d
               tw='absolute text-2xl text-white p-4 mt-28 font-bold'
             >
               {numberWithCommas(Number(data.consensus_accounts_aggregate.aggregate?.count))}
-            </span>
-          </div>
-        </div>
-        <div
-          tw='absolute flex flex-row border-none rounded-[20px] ml-225 mt-65 mb-4 p-6 w-60 h-50'
-          style={{
-            background: 'linear-gradient(180deg, #032372 0%, #1949D2 100%)',
-          }}
-        >
-          <div tw='absolute flex flex-row w-full m-6 justify-center'>
-            <PieChartIcon />
-            <span
-              style={{
-                fontFamily: 'Montserrat',
-              }}
-              tw='absolute text-md text-white mt-24 font-bold'
-            >
-              Total Space Pledged
-            </span>
-            <span
-              style={{
-                fontFamily: 'Montserrat',
-              }}
-              tw='absolute text-2xl text-white p-4 mt-28 font-bold'
-            >
-              {formatSpaceToDecimal(
-                Number(
-                  (data.consensus_blocks[0] as HomeQuery['consensus_blocks'][0])?.space_pledged ||
-                    0,
-                ),
-              )}
             </span>
           </div>
         </div>

--- a/explorer/src/components/Consensus/Block/BlockList.tsx
+++ b/explorer/src/components/Consensus/Block/BlockList.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { formatSpaceToDecimal } from '@autonomys/auto-consensus'
 import { isHex, shortString } from '@autonomys/auto-utils'
 import { AccountIconWithLink } from 'components/common/AccountIcon'
 import { CopyButton } from 'components/common/CopyButton'
@@ -81,30 +80,6 @@ export const BlockList: FC = () => {
         height: {
           ...(filters.heightMin && { _gte: Math.floor(parseFloat(filters.heightMin)).toString() }),
           ...(filters.heightMax && { _lte: Math.floor(parseFloat(filters.heightMax)).toString() }),
-        },
-      }),
-      // Space Pledged
-      ...((filters.spacePledgedMin || filters.spacePledgedMax) && {
-        // eslint-disable-next-line camelcase
-        space_pledged: {
-          ...(filters.spacePledgedMin && {
-            _gte: Math.floor(parseFloat(filters.spacePledgedMin)).toString(),
-          }),
-          ...(filters.spacePledgedMax && {
-            _lte: Math.floor(parseFloat(filters.spacePledgedMax)).toString(),
-          }),
-        },
-      }),
-      // Blockchain Size
-      ...((filters.blockchainSizeMin || filters.blockchainSizeMax) && {
-        // eslint-disable-next-line camelcase
-        blockchain_size: {
-          ...(filters.blockchainSizeMin && {
-            _gte: Math.floor(parseFloat(filters.blockchainSizeMin)).toString(),
-          }),
-          ...(filters.blockchainSizeMax && {
-            _lte: Math.floor(parseFloat(filters.blockchainSizeMax)).toString(),
-          }),
         },
       }),
     }),
@@ -191,8 +166,6 @@ export const BlockList: FC = () => {
             {shortString(row.original.extrinsicsRoot)}
           </CopyButton>
         ),
-        spacePledged: ({ row }: Cell<Row>) => formatSpaceToDecimal(row.original.spacePledged),
-        blockchainSize: ({ row }: Cell<Row>) => formatSpaceToDecimal(row.original.blockchainSize),
       }),
     [network, selectedColumns],
   )

--- a/explorer/src/components/Consensus/Block/query.gql
+++ b/explorer/src/components/Consensus/Block/query.gql
@@ -18,8 +18,6 @@ query Blocks(
     specId: spec_id
     stateRoot: state_root
     extrinsicsRoot: extrinsics_root
-    spacePledged: space_pledged
-    blockchainSize: blockchain_size
     extrinsicsCount: extrinsics_count
     eventsCount: events_count
     authorId: author_id

--- a/explorer/src/components/Consensus/Home/query.gql
+++ b/explorer/src/components/Consensus/Home/query.gql
@@ -5,8 +5,6 @@ query Home($limit: Int!, $offset: Int!) {
     timestamp
     extrinsics_count
     events_count
-    space_pledged
-    blockchain_size
     extrinsicsCount: extrinsics_count
     extrinsics(limit: $limit, offset: $offset, order_by: { sort_id: desc }) {
       id

--- a/explorer/src/constants/tables.ts
+++ b/explorer/src/constants/tables.ts
@@ -33,8 +33,6 @@ export const AVAILABLE_COLUMNS: AvailableColumns = {
     { name: 'specId', label: 'Spec Id', isSelected: false },
     { name: 'stateRoot', label: 'State Root', isSelected: false },
     { name: 'extrinsicsRoot', label: 'Extrinsics Root', isSelected: false },
-    { name: 'spacePledged', label: 'Space Pledged', isSelected: true },
-    { name: 'blockchainSize', label: 'Blockchain Size', isSelected: false },
     { name: 'extrinsicsCount', label: 'Extrinsics', isSelected: true },
     { name: 'eventsCount', label: 'Events', isSelected: true },
     { name: 'authorId', label: 'Block Author', isSelected: true, searchable: true },
@@ -422,10 +420,6 @@ export const INITIAL_TABLES: InitialTables = {
     filters: {
       heightMin: '',
       heightMax: '',
-      spacePledgedMin: '',
-      spacePledgedMax: '',
-      blockchainSizeMin: '',
-      blockchainSizeMax: '',
     },
     sorting: [
       {


### PR DESCRIPTION
closes: #1615 
------
#### Overview
This PR removes the space pledged and blockchain history size fields from block-related queries, components, and UI displays across the explorer application.

#### Changes Made

**Backend/GraphQL:**
- Updated GraphQL queries to remove `space_pledged` and `blockchain_size` fields from block queries
- Modified TypeScript types in `explorer/gql/graphql.tsx` to reflect the removal of these fields
- Updated `BlocksQuery` and `HomeQuery` types to exclude space pledged and blockchain size data

**Frontend Components:**
- **Block List (`BlockList.tsx`):**
  - Removed space pledged and blockchain size column definitions
  - Removed related filter logic for spacePledgedMin/Max and blockchainSizeMin/Max
  - Removed formatters for these fields in table cells

- **Image Generation Routes:**
  - Removed space pledged and history size display cards from consensus image route
  - Removed total space pledged visualization from main image route
  - Cleaned up unused imports (`formatSpaceToDecimal`, `ArchivedHistoryIcon`, `DocIcon`, `PieChartIcon`)

**Configuration:**
- Updated table configuration in `constants/tables.ts`:
  - Removed 'Space Pledged' and 'Blockchain Size' column definitions
  - Removed corresponding filter configurations
  - Cleaned up initial table state

#### Impact
- Simplified block details UI by removing space-related metrics
- Reduced query complexity and payload size
- Streamlined block list filtering options
- Improved page load performance by removing unnecessary data fetching

This refactor aligns with the goal of simplifying the block details interface and removing potentially confusing or less relevant metrics from the user experience.
