### PR TITLE
fix: 🐛 tabs not able to handle single tab

### DIFF
--- a/explorer/src/components/common/Tabs.tsx
+++ b/explorer/src/components/common/Tabs.tsx
@@ -103,7 +103,7 @@ type TabContentProps = {
 
 export const TabContent: React.FC<TabContentProps> = ({ children, selectedTab }) => {
   if (!Array.isArray(children)) {
-    return null
+    return <div>{children}</div>
   }
   if (typeof selectedTab === 'string') {
     return <div id={selectedTab}>{children.find((child) => child.props.id === selectedTab)}</div>


### PR DESCRIPTION
- Fixes the excentrics `events` detais and `folder` files details

![iScreen Shoter - Google Chrome - 250624030102](https://github.com/user-attachments/assets/dfed942b-9ace-4315-b97c-7a610e3fc041)
![iScreen Shoter - Google Chrome - 250624030128](https://github.com/user-attachments/assets/adad56b2-b83c-462e-acb4-1508b161e444)
